### PR TITLE
Add -PMAR option to emit MIDI marker meta-events for P: part labels

### DIFF
--- a/doc/CHANGES
+++ b/doc/CHANGES
@@ -15675,3 +15675,16 @@ February 24 2026
 
 midistats: the summary includes ntimesig, triplets, unquantized when appropriate.
 
+March 30 2026 [RK]
+
+abc2midi: added -PMAR option to emit MIDI marker meta-events (0x06) for
+P: part labels. When a header P: field specifies a play order (e.g.
+P:(AB)3), a marker is emitted each time a section begins during the
+expanded playback, with an instance number (e.g. "Part A-1", "Part B-2").
+When no header P: field is present, inline P: labels in the body are
+emitted as simple section markers (e.g. "Part A"). The existing code at
+genmidi.c:3187 that was meant to write markers was unreachable dead code;
+it has been restructured. Changes in genmidi.c (PART case in writetrack,
+partmarkers global) and store.c (event_part, event_init for -PMAR flag).
+Man page updated in doc/abc2midi.1.
+

--- a/doc/abc2midi.1
+++ b/doc/abc2midi.1
@@ -2,7 +2,7 @@
 .SH NAME
 \fBabc2midi\fP \- converts abc file to MIDI file(s)
 .SH SYNOPSIS
-abc2midi \fIinfile\fP [\fIrefnum\fP] [\-c] [\-v] [\-ver] [\-t] [\-n limit] [\-CS] [\-quiet] [\-silent] [\-Q tempo] [\-NFNP] [\-NFER] [\-NGRA] [\-NGUI] [\-STFW] [\-OCC] [\-NCOM] [\-HARP] [\-BF] [\-TT] [\-o outfile] \-CSM [filename]
+abc2midi \fIinfile\fP [\fIrefnum\fP] [\-c] [\-v] [\-ver] [\-t] [\-n limit] [\-CS] [\-quiet] [\-silent] [\-Q tempo] [\-NFNP] [\-NFER] [\-NGRA] [\-NGUI] [\-STFW] [\-OCC] [\-NCOM] [\-PMAR] [\-HARP] [\-BF] [\-TT] [\-o outfile] \-CSM [filename]
 .SH DESCRIPTION
  The default action is to write a MIDI file for each abc tune
  with the filename <stem>N.mid, where <stem> is the filestem
@@ -60,6 +60,13 @@ Place lyric text in separate MIDI tracks.
 .TP
 .B -NCOM
 Suppress some comments in the output MIDI file.
+.TP
+.B -PMAR
+Emit MIDI marker meta-events for P: part labels. When a header P: field
+specifies a play order (e.g. P:(AB)3), a marker is emitted each time a
+section begins during the expanded playback. When no header P: field is
+present, inline P: labels in the body are emitted as section markers.
+The marker text has the form "Part A", "Part B", etc.
 .TP
 .B -OCC
 Accept old chord convention (eg +D2G2+ instead of [DG]2).

--- a/doc/abc2midi.1
+++ b/doc/abc2midi.1
@@ -64,9 +64,10 @@ Suppress some comments in the output MIDI file.
 .B -PMAR
 Emit MIDI marker meta-events for P: part labels. When a header P: field
 specifies a play order (e.g. P:(AB)3), a marker is emitted each time a
-section begins during the expanded playback. When no header P: field is
-present, inline P: labels in the body are emitted as section markers.
-The marker text has the form "Part A", "Part B", etc.
+section begins during the expanded playback, with an instance number
+appended (e.g. "Part A-1", "Part B-1", "Part A-2", "Part B-2").
+When no header P: field is present, inline P: labels in the body are
+emitted as simple section markers (e.g. "Part A", "Part B").
 .TP
 .B -OCC
 Accept old chord convention (eg +D2G2+ instead of [DG]2).

--- a/genmidi.c
+++ b/genmidi.c
@@ -105,7 +105,7 @@ int gchordbars;
 /* Part handling */
 extern struct vstring part;
 int parts, partno, partlabel;
-int partmarkers; /* -PMAR flag: emit MIDI marker meta-events for P: parts */
+int partmarkers; /* -PMAR flag: emit MIDI marker meta-events for P: parts [RK] 2026-03-30 */
 int part_start[26], part_count[26];
 long introlen, lastlen, partlen[26];
 int partrepno;
@@ -3180,7 +3180,7 @@ int xtrack;
         checksyllables();
       };
       break;
-    case PART:
+    case PART: /* [RK] 2026-03-30 */
       in_varend = 0;
       if (parts == -1) {
         /* No header P: spec, body labels only: emit "Part X" */

--- a/genmidi.c
+++ b/genmidi.c
@@ -105,7 +105,7 @@ int gchordbars;
 /* Part handling */
 extern struct vstring part;
 int parts, partno, partlabel;
-int partmarkers;
+int partmarkers; /* -PMAR flag: emit MIDI marker meta-events for P: parts */
 int part_start[26], part_count[26];
 long introlen, lastlen, partlen[26];
 int partrepno;
@@ -3183,7 +3183,7 @@ int xtrack;
     case PART:
       in_varend = 0;
       if (parts == -1) {
-        /* No header P: spec, body labels only (Scenario B) */
+        /* No header P: spec, body labels only */
         if (partmarkers && xtrack == 0 &&
             pitch[j] >= 'A' && pitch[j] <= 'Z') {
           char msg[8];
@@ -3193,7 +3193,7 @@ int xtrack;
           delta_time_track0 = 0L;
         }
       } else {
-        /* Parts active, navigate then emit marker (Scenario A) */
+        /* Parts active, navigate then emit marker */
         /*j = partbreak(xtrack, trackvoice, j); [SS] 2023.01.20 */
         j = findvoice(j, trackvoice, xtrack);
         if (partmarkers && xtrack == 0 &&

--- a/genmidi.c
+++ b/genmidi.c
@@ -3183,7 +3183,7 @@ int xtrack;
     case PART:
       in_varend = 0;
       if (parts == -1) {
-        /* No header P: spec, body labels only */
+        /* No header P: spec, body labels only: emit "Part X" */
         if (partmarkers && xtrack == 0 &&
             pitch[j] >= 'A' && pitch[j] <= 'Z') {
           char msg[8];
@@ -3193,13 +3193,15 @@ int xtrack;
           delta_time_track0 = 0L;
         }
       } else {
-        /* Parts active, navigate then emit marker */
+        /* Parts active, navigate then emit "Part X-N" marker
+           where N is the instance number (1-based) */
         /*j = partbreak(xtrack, trackvoice, j); [SS] 2023.01.20 */
         j = findvoice(j, trackvoice, xtrack);
         if (partmarkers && xtrack == 0 &&
             partlabel >= 0 && partlabel < 26) {
-          char msg[8];
-          snprintf(msg, sizeof(msg), "Part %c", (char)(partlabel + 'A'));
+          char msg[20];
+          snprintf(msg, sizeof(msg), "Part %c-%d",
+                   (char)(partlabel + 'A'), part_count[partlabel]);
           mf_write_meta_event(delta_time_track0, marker, msg, strlen(msg));
           tracklen = tracklen + delta_time_track0;
           delta_time_track0 = 0L;

--- a/genmidi.c
+++ b/genmidi.c
@@ -105,6 +105,7 @@ int gchordbars;
 /* Part handling */
 extern struct vstring part;
 int parts, partno, partlabel;
+int partmarkers;
 int part_start[26], part_count[26];
 long introlen, lastlen, partlen[26];
 int partrepno;
@@ -3181,15 +3182,29 @@ int xtrack;
       break;
     case PART:
       in_varend = 0;
-      /*j = partbreak(xtrack, trackvoice, j); [SS] 2023.01.20 */
-      j = findvoice(j, trackvoice, xtrack);
-
       if (parts == -1) {
-        char msg[1];
-
-        msg[0] = (char) pitch[j];
-        mf_write_meta_event(0L, marker, msg, 1);
-      };
+        /* No header P: spec, body labels only (Scenario B) */
+        if (partmarkers && xtrack == 0 &&
+            pitch[j] >= 'A' && pitch[j] <= 'Z') {
+          char msg[8];
+          snprintf(msg, sizeof(msg), "Part %c", (char) pitch[j]);
+          mf_write_meta_event(delta_time_track0, marker, msg, strlen(msg));
+          tracklen = tracklen + delta_time_track0;
+          delta_time_track0 = 0L;
+        }
+      } else {
+        /* Parts active, navigate then emit marker (Scenario A) */
+        /*j = partbreak(xtrack, trackvoice, j); [SS] 2023.01.20 */
+        j = findvoice(j, trackvoice, xtrack);
+        if (partmarkers && xtrack == 0 &&
+            partlabel >= 0 && partlabel < 26) {
+          char msg[8];
+          snprintf(msg, sizeof(msg), "Part %c", (char)(partlabel + 'A'));
+          mf_write_meta_event(delta_time_track0, marker, msg, strlen(msg));
+          tracklen = tracklen + delta_time_track0;
+          delta_time_track0 = 0L;
+        }
+      }
       break;
     case VOICE:
       /* search on for next occurrence of voice */

--- a/store.c
+++ b/store.c
@@ -422,7 +422,7 @@ int apply_fermata_to_chord = 0; /* [SS] 2012-03-26 */
 /* Part handling */
 struct vstring part;
 extern int parts, partno, partlabel;
-extern int partmarkers;
+extern int partmarkers; /* [RK] 2026-03-30 */
 extern int part_start[26], part_count[26];
 
 int voicesused;
@@ -955,6 +955,7 @@ char **filename;
     nocom = 0;
   }
 
+  /* [RK] 2026-03-30 */
   if (getarg("-PMAR", argc, argv) != -1) {
     partmarkers = 1;
   } else {
@@ -1055,7 +1056,7 @@ char **filename;
     printf("        -Q default tempo (quarter notes/minute)\n");
     printf("        -NFNP don't process !p! or !f!-like fields\n");
     printf("        -NCOM suppress comments in output MIDI file\n");
-    printf("        -PMAR emit MIDI marker meta-events for P: part labels\n");
+    printf("        -PMAR emit MIDI marker meta-events for P: part labels\n"); /* [RK] 2026-03-30 */
     printf("        -NFER ignore all fermata markings\n");
     printf("        -NGRA ignore grace notes\n");
     printf("        -NGUI ignore guitar chord indications\n");
@@ -2945,7 +2946,7 @@ char* s;
   if (dotune) {
     p = s;
     skipspace(&p);
-    if (pastheader && parts == -1) {
+    if (pastheader && parts == -1) { /* [RK] 2026-03-30 */
       /* No header P: spec. If -PMAR, store body P: as section label */
       if (partmarkers && ((int)*p >= 'A') && ((int)*p <= 'Z')) {
         addfeature(PART, (int)*p, 0, 0);

--- a/store.c
+++ b/store.c
@@ -422,6 +422,7 @@ int apply_fermata_to_chord = 0; /* [SS] 2012-03-26 */
 /* Part handling */
 struct vstring part;
 extern int parts, partno, partlabel;
+extern int partmarkers;
 extern int part_start[26], part_count[26];
 
 int voicesused;
@@ -954,6 +955,12 @@ char **filename;
     nocom = 0;
   }
 
+  if (getarg("-PMAR", argc, argv) != -1) {
+    partmarkers = 1;
+  } else {
+    partmarkers = 0;
+  }
+
   if (getarg("-STFW",argc,argv) != -1) {
     separate_tracks_for_words = 1;
   } else {
@@ -1034,7 +1041,7 @@ char **filename;
     printf("abc2midi version %s\n",VERSION);
     printf("Usage : abc2midi <abc file> [reference number] [-c] [-v] ");
     printf("[-o filename]\n");
-    printf("        [-t] [-n <value>] [-CS] [-NFNP] [-NCOM] [-NFER] [-NGRA] [-NGUI] [-HARP]\n");
+    printf("        [-t] [-n <value>] [-CS] [-NFNP] [-NCOM] [-NFER] [-NGRA] [-NGUI] [-HARP] [-PMAR]\n");
     printf("        [reference number] selects a tune\n");
     printf("        -c  selects checking only\n");
     printf("        -v  selects verbose option\n");
@@ -1048,6 +1055,7 @@ char **filename;
     printf("        -Q default tempo (quarter notes/minute)\n");
     printf("        -NFNP don't process !p! or !f!-like fields\n");
     printf("        -NCOM suppress comments in output MIDI file\n");
+    printf("        -PMAR emit MIDI marker meta-events for P: part labels\n");
     printf("        -NFER ignore all fermata markings\n");
     printf("        -NGRA ignore grace notes\n");
     printf("        -NGUI ignore guitar chord indications\n");
@@ -2937,7 +2945,13 @@ char* s;
   if (dotune) {
     p = s;
     skipspace(&p);
-    if (pastheader && parts == -1) return; /* [SS] 2014-04-10 */
+    if (pastheader && parts == -1) {
+      /* No header P: spec. If -PMAR, store body P: as section label */
+      if (partmarkers && ((int)*p >= 'A') && ((int)*p <= 'Z')) {
+        addfeature(PART, (int)*p, 0, 0);
+      }
+      return;
+    }
     if (pastheader) {
       if (((int)*p < 'A') || ((int)*p > 'Z')) {
         if (!silent) event_error("Part must be one of A-Z");


### PR DESCRIPTION
The P: (Part) field in ABC notation defines musical sections and their play order, but abc2midi never emitted any trace of part information in the generated MIDI file.
The existing code that was meant to write MIDI Marker meta-events (0x06) was unreachable dead code.
This adds a new -PMAR command-line flag that emits SMF Marker meta-events on the conductor track (track 0) for P: part labels, making section structure visible to DAWs and MIDI editors.

Behavior:
- With a header P: spec (e.g., P:(AB)3): a marker is emitted each time a section begins during expanded playback, with a 1-based instance number — "Part A-1", "Part B-1", "Part A-2", "Part B-2", "Part A-3", "Part B-3".
- Without a header P: spec: inline P: labels in the body are emitted as simple section markers — "Part A", "Part B".
- Default behavior is unchanged: no markers are emitted unless -PMAR is explicitly passed.

Example:
  abc2midi tune.abc -PMAR -o tune.mid
