### PR TITLE
abc2midi: allow %%MIDIdef macros to be defined anywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,30 @@ Available presets:
 The CMake build generates `compile_commands.json` for use with
 clangd and other LSP-based editors.
 
+### Testing
+
+The CMake build includes a test suite covering all 8 programs:
+
+- **Smoke tests** verify each binary runs cleanly with `-ver`.
+- **Golden-file tests** run each program on a sample input and compare the
+  (normalized) output to a checked-in reference. Binary MIDI outputs are
+  piped through `mftext` to produce diffable text. Volatile lines (version
+  banners, dates, temporary paths) are stripped before comparison.
+
+```sh
+# Run all tests
+ctest --preset debug
+
+# Run only golden-file tests / only smoke tests
+ctest --preset debug -L golden
+ctest --preset debug -L smoke
+```
+
+To regenerate the golden files after an intentional behavioural change,
+review the diff, then commit:
+
+```sh
+cmake --build build/debug --target update-golden
+git diff tests/golden/
+```
+

--- a/doc/CHANGES
+++ b/doc/CHANGES
@@ -15706,6 +15706,16 @@ in event_refno() in store.c.
 
 Man page updated in doc/abc2midi.1.
 
+March 31 2026 [RK]
+
+abc2midi: allow %%MIDIdef macros to be defined anywhere, including
+before the first X: field (outside any tune). Previously %%MIDIdef was
+only handled inside event_specific() after the started_parsing check,
+so macros defined in the file header were silently ignored. The
+%%MIDIdef handling has been moved before the started_parsing check in
+event_specific() in store.c since macro definitions are
+context-independent.
+
 2026 April 01
 build: added CMake build system (CMakeLists.txt, CMakePresets.json)
 alongside the existing autoconf build.  Three presets are provided:
@@ -15714,4 +15724,3 @@ files (midifile.c, parseabc.c, music_utils.c, parser2.c) are compiled
 once via OBJECT libraries.  The build exports compile_commands.json
 for LSP/clangd support.  Note: the codebase requires -std=gnu89 until
 the K&R-to-ANSI prototype migration is completed.
-

--- a/store.c
+++ b/store.c
@@ -2363,16 +2363,17 @@ void event_specific(char *package, char *s, int in_I)
   char *p;
   int done;
 
-  if (started_parsing == 0) {
-	event_specific_in_header(package,s);
-	return;
-	}
-
-/* [SS] 2015-06-01 */
+/* [SS] 2015-06-01 [RK] 2026-03-31 */
+/* %%MIDIdef macros are context-independent and valid anywhere */
   if (strcmp(package,"MIDIdef") == 0) {
      parse_mididef(s);
      return;
      }
+
+  if (started_parsing == 0) {
+	event_specific_in_header(package,s);
+	return;
+	}
 
   if (strcmp(package,"MIDIx") == 0) {
      process_midix(s);

--- a/tests/golden/abc2midi_coleraine.txt
+++ b/tests/golden/abc2midi_coleraine.txt
@@ -14,6 +14,8 @@ Track end
 Track start
 Time=0  Meta Text, type=0x01 (Text Event)  leng=10
      Text = <note track>
+Time=0  Meta Text, type=0x01 (Text Event)  leng=3
+     Text = <X:8>
 Time=1  Program, chan=1 program=26
 Time=1  Meta Text, type=0x03 (Sequence/Track Name)  leng=9
      Text = <Coleraine>
@@ -21,6 +23,8 @@ Time=1  Meta Text, type=0x01 (Text Event)  leng=18
      Text = <B:Kerr's Violin IV>
 Time=1  Meta Text, type=0x01 (Text Event)  leng=66
      Text = <Z:John Chambers <jc@eddie.mit.edu> http://eddie.mit.edu/~jc/music/>
+Time=1  Meta Text, type=0x01 (Text Event)  leng=5
+     Text = <R:jig>
 Time=1  Program, chan=1 program=72
 Time=1  Parameter, chan=1 c1=7 c2=115
 Time=1  Parameter, chan=1 c1=10 c2=67
@@ -361,12 +365,16 @@ Track end
 Track start
 Time=0  Meta Text, type=0x01 (Text Event)  leng=12
      Text = <gchord track>
+Time=0  Meta Text, type=0x01 (Text Event)  leng=3
+     Text = <X:8>
 Time=1  Program, chan=3 program=3
 Time=1  Program, chan=2 program=3
 Time=1  Meta Text, type=0x01 (Text Event)  leng=18
      Text = <B:Kerr's Violin IV>
 Time=1  Meta Text, type=0x01 (Text Event)  leng=66
      Text = <Z:John Chambers <jc@eddie.mit.edu> http://eddie.mit.edu/~jc/music/>
+Time=1  Meta Text, type=0x01 (Text Event)  leng=5
+     Text = <R:jig>
 Time=1  Parameter, chan=1 c1=7 c2=115
 Time=1  Parameter, chan=1 c1=10 c2=67
 Time=1  Note on, chan=2 pitch=40 vol=65
@@ -932,10 +940,14 @@ Track end
 Track start
 Time=0  Meta Text, type=0x01 (Text Event)  leng=10
      Text = <drum track>
+Time=0  Meta Text, type=0x01 (Text Event)  leng=3
+     Text = <X:8>
 Time=0  Meta Text, type=0x01 (Text Event)  leng=18
      Text = <B:Kerr's Violin IV>
 Time=0  Meta Text, type=0x01 (Text Event)  leng=66
      Text = <Z:John Chambers <jc@eddie.mit.edu> http://eddie.mit.edu/~jc/music/>
+Time=0  Meta Text, type=0x01 (Text Event)  leng=5
+     Text = <R:jig>
 Time=0  Parameter, chan=1 c1=7 c2=115
 Time=0  Parameter, chan=1 c1=10 c2=67
 Time=1  Note on, chan=10 pitch=65 vol=90

--- a/tests/golden/abc2midi_demo.txt
+++ b/tests/golden/abc2midi_demo.txt
@@ -5,8 +5,12 @@ Time=0  Meta Text, type=0x01 (Text Event)  leng=10
 Time=0  Tempo, microseconds-per-MIDI-quarter-note=472440
 Time=0  Key signature, sharp/flats=1  minor=0
 Time=0  Time signature=4/4  MIDI-clocks/click=48  32nd-notes/24-MIDI-clocks=8
+Time=0  Meta Text, type=0x01 (Text Event)  leng=3
+     Text = <X:1>
 Time=0  Meta Text, type=0x03 (Sequence/Track Name)  leng=13
      Text = <Horses Branle>
+Time=0  Meta Text, type=0x01 (Text Event)  leng=6
+     Text = <C:Trad>
 Time=1  Note on, chan=1 pitch=67 vol=105
 Time=360  Note off, chan=1 pitch=67 vol=0
 Time=361  Note on, chan=1 pitch=69 vol=80

--- a/tests/golden/mftext_coleraine.txt
+++ b/tests/golden/mftext_coleraine.txt
@@ -14,6 +14,8 @@ Track end
 Track start
 Time=0  Meta Text, type=0x01 (Text Event)  leng=10
      Text = <note track>
+Time=0  Meta Text, type=0x01 (Text Event)  leng=3
+     Text = <X:8>
 Time=1  Program, chan=1 program=26
 Time=1  Meta Text, type=0x03 (Sequence/Track Name)  leng=9
      Text = <Coleraine>
@@ -21,6 +23,8 @@ Time=1  Meta Text, type=0x01 (Text Event)  leng=18
      Text = <B:Kerr's Violin IV>
 Time=1  Meta Text, type=0x01 (Text Event)  leng=66
      Text = <Z:John Chambers <jc@eddie.mit.edu> http://eddie.mit.edu/~jc/music/>
+Time=1  Meta Text, type=0x01 (Text Event)  leng=5
+     Text = <R:jig>
 Time=1  Program, chan=1 program=72
 Time=1  Parameter, chan=1 c1=7 c2=115
 Time=1  Parameter, chan=1 c1=10 c2=67
@@ -361,12 +365,16 @@ Track end
 Track start
 Time=0  Meta Text, type=0x01 (Text Event)  leng=12
      Text = <gchord track>
+Time=0  Meta Text, type=0x01 (Text Event)  leng=3
+     Text = <X:8>
 Time=1  Program, chan=3 program=3
 Time=1  Program, chan=2 program=3
 Time=1  Meta Text, type=0x01 (Text Event)  leng=18
      Text = <B:Kerr's Violin IV>
 Time=1  Meta Text, type=0x01 (Text Event)  leng=66
      Text = <Z:John Chambers <jc@eddie.mit.edu> http://eddie.mit.edu/~jc/music/>
+Time=1  Meta Text, type=0x01 (Text Event)  leng=5
+     Text = <R:jig>
 Time=1  Parameter, chan=1 c1=7 c2=115
 Time=1  Parameter, chan=1 c1=10 c2=67
 Time=1  Note on, chan=2 pitch=40 vol=65
@@ -932,10 +940,14 @@ Track end
 Track start
 Time=0  Meta Text, type=0x01 (Text Event)  leng=10
      Text = <drum track>
+Time=0  Meta Text, type=0x01 (Text Event)  leng=3
+     Text = <X:8>
 Time=0  Meta Text, type=0x01 (Text Event)  leng=18
      Text = <B:Kerr's Violin IV>
 Time=0  Meta Text, type=0x01 (Text Event)  leng=66
      Text = <Z:John Chambers <jc@eddie.mit.edu> http://eddie.mit.edu/~jc/music/>
+Time=0  Meta Text, type=0x01 (Text Event)  leng=5
+     Text = <R:jig>
 Time=0  Parameter, chan=1 c1=7 c2=115
 Time=0  Parameter, chan=1 c1=10 c2=67
 Time=1  Note on, chan=10 pitch=65 vol=90

--- a/tests/golden/midicopy_coleraine.txt
+++ b/tests/golden/midicopy_coleraine.txt
@@ -14,6 +14,8 @@ Track end
 Track start
 Time=0  Meta Text, type=0x01 (Text Event)  leng=10
      Text = <note track>
+Time=0  Meta Text, type=0x01 (Text Event)  leng=3
+     Text = <X:8>
 Time=1  Program, chan=1 program=26
 Time=1  Meta Text, type=0x03 (Sequence/Track Name)  leng=9
      Text = <Coleraine>
@@ -21,6 +23,8 @@ Time=1  Meta Text, type=0x01 (Text Event)  leng=18
      Text = <B:Kerr's Violin IV>
 Time=1  Meta Text, type=0x01 (Text Event)  leng=66
      Text = <Z:John Chambers <jc@eddie.mit.edu> http://eddie.mit.edu/~jc/music/>
+Time=1  Meta Text, type=0x01 (Text Event)  leng=5
+     Text = <R:jig>
 Time=1  Program, chan=1 program=72
 Time=1  Parameter, chan=1 c1=7 c2=115
 Time=1  Parameter, chan=1 c1=10 c2=67
@@ -361,12 +365,16 @@ Track end
 Track start
 Time=0  Meta Text, type=0x01 (Text Event)  leng=12
      Text = <gchord track>
+Time=0  Meta Text, type=0x01 (Text Event)  leng=3
+     Text = <X:8>
 Time=1  Program, chan=3 program=3
 Time=1  Program, chan=2 program=3
 Time=1  Meta Text, type=0x01 (Text Event)  leng=18
      Text = <B:Kerr's Violin IV>
 Time=1  Meta Text, type=0x01 (Text Event)  leng=66
      Text = <Z:John Chambers <jc@eddie.mit.edu> http://eddie.mit.edu/~jc/music/>
+Time=1  Meta Text, type=0x01 (Text Event)  leng=5
+     Text = <R:jig>
 Time=1  Parameter, chan=1 c1=7 c2=115
 Time=1  Parameter, chan=1 c1=10 c2=67
 Time=1  Note on, chan=2 pitch=40 vol=65
@@ -932,10 +940,14 @@ Track end
 Track start
 Time=0  Meta Text, type=0x01 (Text Event)  leng=10
      Text = <drum track>
+Time=0  Meta Text, type=0x01 (Text Event)  leng=3
+     Text = <X:8>
 Time=0  Meta Text, type=0x01 (Text Event)  leng=18
      Text = <B:Kerr's Violin IV>
 Time=0  Meta Text, type=0x01 (Text Event)  leng=66
      Text = <Z:John Chambers <jc@eddie.mit.edu> http://eddie.mit.edu/~jc/music/>
+Time=0  Meta Text, type=0x01 (Text Event)  leng=5
+     Text = <R:jig>
 Time=0  Parameter, chan=1 c1=7 c2=115
 Time=0  Parameter, chan=1 c1=10 c2=67
 Time=1  Note on, chan=10 pitch=65 vol=90


### PR DESCRIPTION
Fix also some lost CHANGES from previous commit.

Update the golden test files since X:, R: and C: are now emitted.

abc2midi: allow %%MIDIdef macros to be defined anywhere, including before the first X: field (outside any tune). Previously %%MIDIdef was only handled inside event_specific() after the started_parsing check,so macros defined in the file header were silently ignored. The %%MIDIdef handling has been moved before the started_parsing check in event_specific() in store.c since macro definitions are context-independent.