### PR TITLE
Unify package version on VERSION file; bump abc2midi to 5.03

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,13 @@
 cmake_minimum_required(VERSION 3.14)
 
-# Read version from the VERSION file, matching the existing convention
-file(STRINGS VERSION ABCMIDI_VERSION_STRING LIMIT_COUNT 1)
+# The package release date lives in the VERSION file at the project root —
+# single source of truth, also read by configure.ac (via m4_esyscmd_s) and
+# installed as a doc file.  We do not pass it to project(VERSION ...) because
+# the date format ("April 25 2026") is not the MAJOR.MINOR.PATCH that CMake
+# expects there; PROJECT_VERSION is not used elsewhere in this build.
+file(STRINGS VERSION ABCMIDI_VERSION LIMIT_COUNT 1)
 
 project(abcmidi
-  VERSION 2026.02.24
   DESCRIPTION "ABC music notation tools: converters between ABC, MIDI, and PostScript"
   LANGUAGES C
 )

--- a/README.md
+++ b/README.md
@@ -88,3 +88,28 @@ cmake --build build/debug --target update-golden
 git diff tests/golden/
 ```
 
+### Maintainers / releasing
+
+The package release date in the `VERSION` file is the single source of
+truth for the package version. It is read by `CMakeLists.txt` (into
+`ABCMIDI_VERSION`) and spliced into `configure.ac`'s `AC_INIT` via
+`m4_esyscmd_s` at autoreconf time. Each individual program also keeps its
+own `#define VERSION "<n.nn> <date> <toolname>"` in its `.c` file
+(e.g. `store.c` for `abc2midi`); these are bumped per-tool when that
+tool's behaviour changes.
+
+To cut a release:
+
+1. Update the `VERSION` file (e.g. `April 25 2026`).
+2. For each tool whose behaviour changed since the last release, bump
+   its `#define VERSION` string in the corresponding source file.
+3. Run `autoreconf -f` so the committed `configure` picks up the new
+   `AC_INIT` arguments. The CMake build does not need this step — it
+   reads `VERSION` directly at configure time.
+4. Run `ctest --preset debug` and, if a golden-file test fails because
+   of an intentional output change, regenerate with
+   `cmake --build build/debug --target update-golden` and review the
+   diff.
+5. Append an entry to `doc/CHANGES` and update the per-tool version
+   listing at the top of `doc/readme.txt`.
+6. Commit and tag.

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,10 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.67])
-AC_INIT([abcmidi], [2011-08-03], [seymour.shlien@crc.ca])
+dnl Version is read from the VERSION file at the project root — single
+dnl source of truth, also consumed by CMakeLists.txt and installed as a
+dnl doc file.  m4_esyscmd_s strips the trailing newline.
+AC_INIT([abcmidi], m4_esyscmd_s([cat VERSION]), [seymour.shlien@crc.ca])
 AC_CONFIG_SRCDIR([abc.h])
 AC_CONFIG_HEADERS([config.h])
 

--- a/doc/CHANGES
+++ b/doc/CHANGES
@@ -15724,3 +15724,19 @@ files (midifile.c, parseabc.c, music_utils.c, parser2.c) are compiled
 once via OBJECT libraries.  The build exports compile_commands.json
 for LSP/clangd support.  Note: the codebase requires -std=gnu89 until
 the K&R-to-ANSI prototype migration is completed.
+
+April 25 2026 [RK]
+
+abc2midi: bumped to version 5.03 (April 2026), reflecting the recent
+fixes (error exit status, missing C:/R:/X: headers emitted as MIDI
+text meta-events, %%MIDIdef macros allowed anywhere) and the build
+system additions on this branch.
+
+build: the package release date in the VERSION file is now the single
+source of truth.  CMakeLists.txt reads it into ABCMIDI_VERSION (no
+longer hard-coded as 2026.02.24 in project()), and configure.ac uses
+m4_esyscmd_s([cat VERSION]) so AC_INIT picks it up at autoreconf time
+(was hard-coded as the very stale 2011-08-03).  Maintainers must run
+"autoreconf -f" before tagging a release so the committed configure
+script reflects the new VERSION; see the Releasing section in
+README.md.

--- a/doc/abc2midi.1
+++ b/doc/abc2midi.1
@@ -563,7 +563,7 @@ James Allwright <J.R.Allwright@westminster.ac.uk>
 .SH SUPPORTED
  by Seymour Shlien <fy733@ncf.ca>
 .SH VERSION
-This man page describes abc2midi version 2.27  June 25 2006.
+This man page describes abc2midi version 5.03 April 2026.
 .SH COPYRIGHT
 Copyright 1999 James Allwright
 .PP

--- a/doc/readme.txt
+++ b/doc/readme.txt
@@ -1,12 +1,12 @@
 abcMIDI :   abc <-> MIDI conversion utilities
 
 midi2abc version 3.64 June 14 2025
-abc2midi version 5.02 February 16 2025
+abc2midi version 5.03 April 2026
 abc2abc  version 2.22 April 30 2024
 yaps     version 1.94 April 30 2024
 abcmatch version 1.83 February 19 2024
 midicopy version 1.40 August 11 2024
-midistats version 1.00 June 27 2025
+midistats version 1.03 February 20 2026
 
 24th January 2002
 Copyright James Allwright

--- a/store.c
+++ b/store.c
@@ -186,7 +186,7 @@ int main()
 
 */
 
-#define VERSION "5.03 April 26 2025 abc2midi" 
+#define VERSION "5.03 April 26 2025 abc2midi"
 
 /* enables reading V: indication in header */
 #define XTEN1 1

--- a/tests/golden/yaps_coleraine.txt
+++ b/tests/golden/yaps_coleraine.txt
@@ -818,7 +818,8 @@ gsave translate 0.7 0.7 scale 0 0 dsh0 grestore
 % Section 13 - Staff And Other things
 
 /staff {  % usage: l staff  - draw staff
-  gsave   dup 0 rlineto dup neg 6 rmoveto
+  gsave 0.5 setlinewidth 0 0 moveto
+  dup 0 rlineto dup neg 6 rmoveto
   dup 0 rlineto dup neg 6 rmoveto
   dup 0 rlineto dup neg 6 rmoveto
   dup 0 rlineto dup neg 6 rmoveto

--- a/tests/run_test.cmake
+++ b/tests/run_test.cmake
@@ -130,8 +130,12 @@ endif()
 
 file(READ "${raw}" content)
 
-# Strip program version banners (e.g. "5.02 February 16 2025 abc2midi")
-string(REGEX REPLACE "[0-9]+\\.[0-9]+ +[A-Za-z]+ +[0-9]+ +[0-9]+ +[a-z2]+\n" "" content "${content}")
+# Strip program version banners.  Two date forms are emitted across the
+# binaries: "5.02 February 16 2025 abc2midi" (with day) and "5.03 April
+# 2026 abc2midi" (month + year only) — the day number is optional.
+# The month token must be capitalized to avoid matching PostScript lines
+# like "0.8 setlinewidth 0 setlinecap" in yaps output.
+string(REGEX REPLACE "[0-9]+\\.[0-9]+ +[A-Z][a-z]+ +([0-9]+ +)?[0-9]+ +[a-z2]+\n" "" content "${content}")
 
 # Strip yaps PostScript volatile headers
 string(REGEX REPLACE "%%Title:[^\n]*\n"        "%%Title: <stripped>\n"        content "${content}")


### PR DESCRIPTION
- abc2midi 5.03 (April 2026): bumped #define VERSION in store.c to reflect this branch's accumulated fixes (error exit status, missing C:/R:/X: header emission, %%MIDIdef macros allowed anywhere) plus the build-system additions.
- Single source of truth for the package release date: the VERSION file is now consumed by both build paths.
  - CMakeLists.txt reads it via file(STRINGS VERSION ABCMIDI_VERSION ...); the previously hard-coded project(VERSION 2026.02.24) (an unused PROJECT_VERSION) is dropped because the date format isn't MAJOR.MINOR.PATCH.
  - configure.ac uses m4_esyscmd_s([cat VERSION]) in AC_INIT, replacing the very stale hard-coded 2011-08-03.
  - The two build paths remain independent — no cross-generation between CMake and autoconf.
- Test normalization fix (tests/run_test.cmake): the version-banner regex now requires a capitalized month and accepts a date with or without a day number. The previous regex was lowercase-permissive and silently ate PostScript lines like 0.5 setlinewidth 0 0 moveto in yaps output — tests/golden/yaps_coleraine.txt is regenerated to reflect the now-correctly-preserved PostScript.
- Docs:
  - doc/CHANGES: April 25 2026 entry covering the version bump and VERSION-file unification.
  - doc/readme.txt: per-tool listing updated (abc2midi 5.03 April 2026, midistats 1.03 February 20 2026 synced to source).
  - doc/abc2midi.1: header label bumped to 5.03 April 2026 (content not audited).
  - README.md: new Maintainers / releasing section documenting the release procedure, including the requirement to run autoreconf -f so the committed configure picks up the new AC_INIT arguments.