### PR TITLE
build: lower CMakePresets.json schema to v3 for older cmake compat

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,6 +1,6 @@
 {
-  "version": 6,
-  "cmakeMinimumRequired": { "major": 3, "minor": 25, "patch": 0 },
+  "version": 3,
+  "cmakeMinimumRequired": { "major": 3, "minor": 21, "patch": 0 },
   "configurePresets": [
     {
       "name": "default",

--- a/doc/CHANGES
+++ b/doc/CHANGES
@@ -15740,3 +15740,12 @@ m4_esyscmd_s([cat VERSION]) so AC_INIT picks it up at autoreconf time
 "autoreconf -f" before tagging a release so the committed configure
 script reflects the new VERSION; see the Releasing section in
 README.md.
+
+May 7 2026 [RK]
+
+build: lowered CMakePresets.json schema from v6 to v3 (and
+cmakeMinimumRequired from 3.25 to 3.21) so users on older CMake
+releases such as the 3.22.1 shipped by Ubuntu 22.04 LTS can use
+"cmake --preset" without hitting "Unrecognized 'version' field".  No
+v4/v5/v6 schema features were in use; v3 covers every field present
+in the file.


### PR DESCRIPTION
## Summary

- Drop ``CMakePresets.json`` schema from v6 to v3 and ``cmakeMinimumRequired`` from 3.25 to 3.21.
- Users on older but still common cmake releases (notably the 3.22.1 in Ubuntu 22.04 LTS) currently hit ``CMake Error: Could not read presets ... Unrecognized "version" field`` when running ``cmake --preset``. v3 fixes that.
- No behavioural change. The file uses no v4/v5/v6 schema features — only ``configurePresets``/``buildPresets``/``testPresets`` with ``cacheVariables``, ``binaryDir``, ``displayName``, ``output.outputOnFailure``, and ``environment``. v3 is the lowest schema where ``generator`` stays optional, so cmake keeps picking the default; v2 would have required adding an explicit ``generator`` field to every preset.

Reported via private email by Seymour Shlien hitting this on his Ubuntu VM (cmake 3.22.1).

## Test plan

- [x] ``cmake --preset default && cmake --build --preset default && ctest --preset default`` — 19/19 pass.
- [x] ``cmake --preset debug && cmake --build --preset debug``
- [x] ``cmake --preset sanitize && cmake --build --preset sanitize``
- [ ] (optional) Confirm on cmake 3.22.x that ``cmake --preset default`` no longer reports "Unrecognized 'version' field".

🤖 Generated with [Claude Code](https://claude.com/claude-code)