### PR TITLE
fix(midifile): resolve Mf_* function pointer type conflicts between .c and .h

### DIFF
--- a/mftext.c
+++ b/mftext.c
@@ -153,10 +153,10 @@ void txt_metamisc(int type, int leng, char *mess)
   printf("Meta event, unrecognized, type=0x%02x leng=%d\n",type,leng);
 }
 
-void txt_metaspecial(int type, int leng, char *mess)
+void txt_metaspecial(int leng, char *mess)
 {
   prtime();
-  printf("Meta event, sequencer-specific, type=0x%02x leng=%d\n",type,leng);
+  printf("Meta event, sequencer-specific, leng=%d\n", leng);
 }
 
 void txt_metatext(int type, int leng, char *mess)

--- a/midi2abc.c
+++ b/midi2abc.c
@@ -733,7 +733,7 @@ void txt_metamisc(int type, int leng, char *mess)
 {
 }
 
-void txt_metaspecial(int type, int leng, char *mess)
+void txt_metaspecial(int leng, char *mess)
 {
 }
 
@@ -901,6 +901,7 @@ void txt_arbitrary(int leng, char *mess)
  void no_op3_iis(int dummy1, int dummy2, char * dummy3) { }
  void no_op4(int dummy1, int dummy2, int dummy3, int dummy4) { }
  void no_op5(int dummy1, int dummy2, int dummy3, int dummy4, int dummy5) { }
+ void no_op_l(long dummy1) {}
 
 
 void print_txt_header(int xformat, int ntrks, int ldivision)
@@ -1429,11 +1430,11 @@ void initfunc_for_midinotes()
     Mf_eot = &no_op0;
     Mf_timesig = &no_op4;
     Mf_smpte = &no_op5;
-    Mf_tempo = &no_op1;
+    Mf_tempo = &no_op_l;
     Mf_keysig = &no_op2;
-    Mf_seqspecific = &no_op3;
-    Mf_text = &no_op3;
-    Mf_arbitrary = &no_op2;
+    Mf_seqspecific = &no_op2_is;
+    Mf_text = &no_op3_iis;
+    Mf_arbitrary = &no_op2_is;
 }
 
 void initfunc_for_midipitch()
@@ -1465,9 +1466,9 @@ void initfunc_for_mftext()
     Mf_smpte = &mftxt_smpte;
     Mf_tempo = &mftxt_tempo;
     Mf_keysig = &mftxt_keysig;
-    Mf_seqspecific = &no_op3;
+    Mf_seqspecific = &no_op2_is;
     Mf_text = &mftxt_metatext;
-    Mf_arbitrary = &no_op2;
+    Mf_arbitrary = &no_op2_is;
 }
 
 

--- a/midifile.c
+++ b/midifile.c
@@ -63,12 +63,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#ifdef ANSILIBS
 #include <string.h>
-#include <stdlib.h>
-#else
-char *strcpy(), *strcat();
-#endif
 
 /* int exit(), free(); */ /* Line commmented out JRA 19/12/95 */
 
@@ -76,20 +71,20 @@ char *strcpy(), *strcat();
 
 /* Functions to be called while processing the MIDI file. */
 int (*Mf_getc)() = NULLFUNC;
-void (*Mf_error)() = NULLFUNC;
+void (*Mf_error)(char *) = NULLFUNC;
 void (*Mf_header)(int, int, int) = NULLFUNC;
 void (*Mf_trackstart)() = NULLFUNC;
 void (*Mf_trackend)() = NULLFUNC;
-void (*Mf_noteon)() = NULLFUNC;
-void (*Mf_noteoff)() = NULLFUNC;
-void (*Mf_pressure)() = NULLFUNC;
-void (*Mf_parameter)() = NULLFUNC;
-void (*Mf_pitchbend)() = NULLFUNC;
-void (*Mf_program)() = NULLFUNC;
-void (*Mf_chanpressure)() = NULLFUNC;
-void (*Mf_sysex)() = NULLFUNC;
+void (*Mf_noteon)(int, int, int) = NULLFUNC;
+void (*Mf_noteoff)(int, int, int) = NULLFUNC;
+void (*Mf_pressure)(int, int, int) = NULLFUNC;
+void (*Mf_parameter)(int, int, int) = NULLFUNC;
+void (*Mf_pitchbend)(int, int, int) = NULLFUNC;
+void (*Mf_program)(int, int) = NULLFUNC;
+void (*Mf_chanpressure)(int, int, int) = NULLFUNC;
+void (*Mf_sysex)(int, char *) = NULLFUNC;
 void (*Mf_arbitrary)(int, char *) = NULLFUNC;
-void (*Mf_metamisc)() = NULLFUNC;
+void (*Mf_metamisc)(int, int, char *) = NULLFUNC;
 void (*Mf_seqnum)(int) = NULLFUNC;
 void (*Mf_eot)() = NULLFUNC;
 void (*Mf_smpte)(int,int,int,int,int) = NULLFUNC;

--- a/midifile.h
+++ b/midifile.h
@@ -1,7 +1,7 @@
 /* definitions for MIDI file parsing code */
 #include <stdio.h>
 extern int (*Mf_getc)();
-extern void (*Mf_header)();
+extern void (*Mf_header)(int, int, int);
 extern void (*Mf_trackstart)();
 extern void (*Mf_trackend)();
 extern void (*Mf_noteon)(int, int, int);
@@ -11,24 +11,24 @@ extern void (*Mf_parameter)(int, int, int);
 extern void (*Mf_pitchbend)(int, int, int);
 extern void (*Mf_program)(int, int);
 extern void (*Mf_chanpressure)(int, int, int);
-extern void (*Mf_sysex)(int leng, char *mess);
+extern void (*Mf_sysex)(int, char *);
 extern void (*Mf_metamisc)(int, int, char *);
-extern void (*Mf_seqspecific)();
-extern void (*Mf_seqnum)();
-extern void (*Mf_text)();
+extern void (*Mf_seqspecific)(int, char *);
+extern void (*Mf_seqnum)(int);
+extern void (*Mf_text)(int, int, char *);
 extern void (*Mf_eot)();
 extern void (*Mf_timesig)(int,int,int,int);
 extern void (*Mf_smpte)(int,int,int,int,int);
-extern void (*Mf_tempo)();
+extern void (*Mf_tempo)(long);
 extern void (*Mf_keysig)(int, int);
-extern void (*Mf_arbitrary)();
+extern void (*Mf_arbitrary)(int, char *);
 extern void (*Mf_error)(char *);
 extern long Mf_currtime;
 extern int Mf_nomerge;
 
 /* definitions for MIDI file writing code */
 extern int (*Mf_putc)(char c);
-extern long (*Mf_writetrack)();
+extern long (*Mf_writetrack)(int);
 extern int (*Mf_writetempotrack)();
 float mf_ticks2sec(long ticks, int division, long tempo);
 long mf_sec2ticks(float secs, int division, long tempo);

--- a/midistats.c
+++ b/midistats.c
@@ -1224,9 +1224,9 @@ void initfunc_for_stats()
     Mf_smpte = no_op5;
     Mf_tempo = stats_tempo;
     Mf_keysig = stats_keysig;
-    Mf_seqspecific = no_op3;
+    Mf_seqspecific = no_op2_is;
     Mf_text = stats_metatext;
-    Mf_arbitrary = no_op2;
+    Mf_arbitrary = no_op2_is;
     for (i = 0; i< 2047; i++) pulseCounter[i] = 0;
 }
 
@@ -1242,7 +1242,7 @@ void initfunc_for_loadNoteEvents()
     Mf_pressure = no_op3;
     Mf_parameter = no_op3;
     Mf_pitchbend = no_op3;
-    Mf_program = no_op0;
+    Mf_program = no_op2;
     Mf_chanpressure = no_op3;
     Mf_sysex = no_op2_is;
     Mf_metamisc = no_op3_iis;
@@ -1252,9 +1252,9 @@ void initfunc_for_loadNoteEvents()
     Mf_smpte = no_op5;
     Mf_tempo = record_tempo;
     Mf_keysig = no_op2;
-    Mf_seqspecific = no_op3;
-    Mf_text = no_op3;
-    Mf_arbitrary = no_op2;
+    Mf_seqspecific = no_op2_is;
+    Mf_text = no_op3_iis;
+    Mf_arbitrary = no_op2_is;
 }
 
 void dumpMidievents (int from , int to)


### PR DESCRIPTION
## Summary

- `midifile.c` and `midifile.h` had contradictory ANSI parameter types on the `Mf_*` function pointer declarations — explicit types were applied to opposite halves of the set in each file by commit 7b0b1cc (PR #15). In C23, empty `()` now means *no parameters* rather than *unspecified*, so gcc 16 (MSYS2 UCRT64) and clang emit hard errors.
- Several `no_op*` assignments in `midistats.c` and `midi2abc.c` passed wrongly-typed stubs (e.g. `no_op3(int,int,int)` where `Mf_seqspecific(int,char*)` was expected).
- `txt_metaspecial` had a 3-parameter signature but `Mf_seqspecific` is called with 2 arguments from `midifile.c`, causing the first two actual args to land in the wrong parameters.

## Changes

| File | Fix |
|------|-----|
| `midifile.c` | Make `#include <string.h>` unconditional; drop K&R `char *strcpy(), *strcat()` fallback; add param types to `Mf_error`, `Mf_noteon`, `Mf_noteoff`, `Mf_pressure`, `Mf_parameter`, `Mf_pitchbend`, `Mf_program`, `Mf_chanpressure`, `Mf_sysex`, `Mf_metamisc` |
| `midifile.h` | Add param types to `Mf_header`, `Mf_seqspecific`, `Mf_seqnum`, `Mf_text`, `Mf_tempo`, `Mf_arbitrary`, `Mf_writetrack` |
| `midistats.c` | Fix type-mismatched no-op assignments in `initfunc_for_stats` and `initfunc_for_loadNoteEvents` |
| `midi2abc.c` | Add `no_op_l(long)` for `Mf_tempo`; fix no-op mismatches in `initfunc_for_midinotes` and `initfunc_for_mftext`; fix `txt_metaspecial` signature |
| `mftext.c` | Fix `txt_metaspecial` signature to `(int leng, char *mess)` to match call site |

## Test plan

- [x] Builds cleanly with no new errors or incompatible-pointer warnings
- [x] All 19 existing tests pass (`ctest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)