### PR TITLE
ci: add MSYS2 UCRT64 build job to catch Windows type errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,30 @@ permissions:
   contents: read
 
 jobs:
+  test-msys2:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-ninja
+      - name: Configure
+        run: cmake --preset default
+      - name: Build
+        run: cmake --build --preset default
+      - name: Test
+        run: ctest --preset default --output-on-failure
+
   test:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Adds a Windows runner using msys2/setup-msys2 with the UCRT64 environment — the same toolchain (gcc 16) that reported the Mf_* function pointer conflicts.  Runs the full cmake build and test suite so regressions are caught on both Linux and Windows.