### PR TITLE
abc2midi: add -lyrics option to emit standard MIDI Lyric (0x05) events

### DIFF
--- a/doc/CHANGES
+++ b/doc/CHANGES
@@ -15749,3 +15749,18 @@ releases such as the 3.22.1 shipped by Ubuntu 22.04 LTS can use
 "cmake --preset" without hitting "Unrecognized 'version' field".  No
 v4/v5/v6 schema features were in use; v3 covers every field present
 in the file.
+
+May 30 2026 [RK]
+
+abc2midi: new -lyrics option.  When a tune has w: word lines, abc2midi
+normally renders them in the Soft-Karaoke convention: 0x01 Text
+meta-events, an "@KMIDI KARAOKE FILE" / "@I" header on the conductor
+track, and a "/" or "\" line/paragraph prefix on the first syllable of
+each w: line.  With -lyrics the words are instead emitted as standard
+MIDI Lyric (0x05) meta-events carrying just the bare syllable text,
+still synchronized to their notes, with the karaoke-specific decoration
+suppressed (the standard sequence-name title is retained).  Default
+behaviour is unchanged.  Implemented in genmidi.c (new word_data()
+helper and lyrics_meta guards in getword() and karaokestarttrack()) and
+store.c (flag parsing); regression-pinned by the tests/golden
+abc2midi_lyrics_demo_5 golden.

--- a/doc/abc2midi.1
+++ b/doc/abc2midi.1
@@ -2,7 +2,7 @@
 .SH NAME
 \fBabc2midi\fP \- converts abc file to MIDI file(s)
 .SH SYNOPSIS
-abc2midi \fIinfile\fP [\fIrefnum\fP] [\-c] [\-v] [\-ver] [\-t] [\-n limit] [\-CS] [\-quiet] [\-silent] [\-Q tempo] [\-NFNP] [\-NFER] [\-NGRA] [\-NGUI] [\-STFW] [\-OCC] [\-NCOM] [\-PMAR] [\-HARP] [\-BF] [\-TT] [\-o outfile] \-CSM [filename]
+abc2midi \fIinfile\fP [\fIrefnum\fP] [\-c] [\-v] [\-ver] [\-t] [\-n limit] [\-CS] [\-quiet] [\-silent] [\-Q tempo] [\-NFNP] [\-NFER] [\-NGRA] [\-NGUI] [\-STFW] [\-lyrics] [\-OCC] [\-NCOM] [\-PMAR] [\-HARP] [\-BF] [\-TT] [\-o outfile] \-CSM [filename]
 .SH DESCRIPTION
  The default action is to write a MIDI file for each abc tune
  with the filename <stem>N.mid, where <stem> is the filestem
@@ -57,6 +57,12 @@ Ignore any guitar chords enclosed in double quotes.
 .TP
 .B -STFW
 Place lyric text in separate MIDI tracks.
+.TP
+.B -lyrics
+Emit the w: words as standard MIDI Lyric (0x05) meta-events carrying the
+bare syllable text, instead of the default Soft-Karaoke rendering (0x01
+Text events with the @KMIDI KARAOKE FILE / @I header lines and the / and \\
+line/paragraph prefixes). The syllables remain synchronized to their notes.
 .TP
 .B -NCOM
 Suppress some comments in the output MIDI file.

--- a/genmidi.c
+++ b/genmidi.c
@@ -164,6 +164,7 @@ int single_velocity;
 
 /* karaoke handling */
 extern int karaoke, wcount;
+extern int lyrics_meta; /* [RK] 2026-05-30 -lyrics: 0x05 Lyric meta-events */
 int kspace;
 char* wordlineptr;
 extern char** words;
@@ -693,8 +694,19 @@ static int findvoice(int initplace, int voice, int xtrack)
 
 static void text_data(char *s)
 /* write text event to MIDI file */
-{   
+{
   mf_write_meta_event(delta_time, text_event, s, strlen(s));
+  tracklen = tracklen + delta_time;
+  delta_time = 0L;
+}
+
+/* [RK] 2026-05-30 */
+static void word_data(char *s)
+/* Write one lyric syllable to the MIDI file.  With -lyrics it is emitted as a
+ * standard MIDI Lyric (0x05) meta-event; otherwise as a Text (0x01) event,
+ * which is the Soft-Karaoke convention. */
+{
+  mf_write_meta_event(delta_time, lyrics_meta ? lyric : text_event, s, strlen(s));
   tracklen = tracklen + delta_time;
   delta_time = 0L;
 }
@@ -710,7 +722,9 @@ static void karaokestarttrack (int track)
  *  Print Karaoke file headers in track 0.
  *  @KMIDI KARAOKE FILE - Karaoke midi file marker)
  */
-   if (track == 0)
+   /* [RK] 2026-05-30 the @KMIDI marker is Soft-Karaoke specific; -lyrics
+    * keeps only the standard sequence-name title written below. */
+   if ((track == 0) && (!lyrics_meta))
    {
       text_data("@KMIDI KARAOKE FILE");
    }
@@ -742,21 +756,23 @@ static void karaokestarttrack (int track)
      
   while ((j < notes) && (done > 0))
   {
+     /* [RK] 2026-05-30 the @I/@T info lines are Soft-Karaoke markers; with
+      * -lyrics only the standard sequence-name title (above) is kept. */
      if (feature[j] == TITLE) {
         if (track != 2)
            mf_write_meta_event(0L, sequence_name, atext[pitch[j]], strlen (atext[pitch[j]]));
         strncpy(atitle+2, atext[pitch[j]], 197); /* [KG] 2022-01-13 stack overflow bug */
-        text_data(atitle);
+        if (!lyrics_meta) text_data(atitle);
         done--;
      }
      if (feature[j] == COMPOSER) {
         strncpy(atitle+2, atext[pitch[j]], 197); /* [KG] 2022-01-13 stack overflow bug */
-        text_data(atitle);
+        if (!lyrics_meta) text_data(atitle);
         done--;
-     }     
+     }
      if (feature[j] == COPYRIGHT) {
         strcpy(atitle+2, atext[pitch[j]]); /* [KG] 2022-01-13 stack overflow bug */
-        text_data(atitle);
+        if (!lyrics_meta) text_data(atitle);
         done--;
      }
      j = j+1;
@@ -921,11 +937,13 @@ static int getword(int *place, int w)
     syllable[i] = '\0';
     return ('\0');
   };
-  if (*place == 0) {
+  /* [RK] 2026-05-30 the / and \ line/paragraph markers are a Soft-Karaoke
+   * convention; with -lyrics we emit just the bare words. */
+  if ((*place == 0) && (!lyrics_meta)) {
     if ((w % 2) == 0) {
-      syllable[i] = '/'; 
+      syllable[i] = '/';
     } else {
-      syllable[i] = '\\'; 
+      syllable[i] = '\\';
     };
     i = i + 1;
   };
@@ -1054,7 +1072,7 @@ static int getword(int *place, int w)
   } else {
     syllcount = 1;
     if (strlen(syllable) > 0) {
-      text_data(syllable);
+      word_data(syllable);
       /*printf("TEXT DATA %s\n",syllable);*/
     };
   };

--- a/samples/words.abc
+++ b/samples/words.abc
@@ -1,0 +1,18 @@
+% Lyric/word handling coverage for the golden test suite.
+% Small, deliberately exercises w: control codes: a hyphen-split word
+% (hy-phen), a melisma hold (_), a hard space joining two words into one
+% syllable (a~b), a blank syllable (*), and a line break between two w:
+% lines.  Rendered both with the default Soft-Karaoke output (0x01 Text,
+% with the / and \ line/paragraph prefixes) and with -lyrics (bare 0x05
+% Lyric events) so the contrast between the two is pinned.
+X:1
+T:Word and lyric handling
+C:abc2midi test
+M:4/4
+L:1/4
+Q:1/4=120
+K:C
+C D E F |
+w:plain hy-phen end
+G A B c |
+w:hold _ a~b *

--- a/store.c
+++ b/store.c
@@ -473,6 +473,9 @@ int programbase = 0; /* [SS] 2017-06-02 */
 
 /* karaoke handling */
 int karaoke, wcount;
+/* [RK] 2026-05-30 -lyrics: emit words as standard MIDI Lyric (0x05)
+ * meta-events instead of the Soft-Karaoke Text (0x01) convention. */
+int lyrics_meta;
 char** words;
 int maxwords = INITWORDS;
 
@@ -954,6 +957,13 @@ void event_init(int argc, char *argv[], char **filename)
     partmarkers = 0;
   }
 
+  /* [RK] 2026-05-30 */
+  if (getarg("-lyrics", argc, argv) != -1) {
+    lyrics_meta = 1;
+  } else {
+    lyrics_meta = 0;
+  }
+
   if (getarg("-STFW",argc,argv) != -1) {
     separate_tracks_for_words = 1;
   } else {
@@ -1053,6 +1063,7 @@ void event_init(int argc, char *argv[], char **filename)
     printf("        -NGRA ignore grace notes\n");
     printf("        -NGUI ignore guitar chord indications\n");
     printf("        -STFW separate tracks for words (lyrics)\n");
+    printf("        -lyrics emit lyrics as standard MIDI Lyric (0x05) meta-events\n"); /* [RK] 2026-05-30 */
     printf("        -HARP ornaments=roll for harpist (same pitch)\n"); /* [JS] 2011-04-29 */
     printf("        -BF Barfly mode: invokes a stress model if possible\n");
     printf("        -OCC old chord convention (eg. +CE+)\n");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -98,6 +98,7 @@ set(EXTRA_SAMPLES
   detune.abc
   drums.abc
   temperament.abc
+  words.abc
 )
 foreach(sample IN LISTS EXTRA_SAMPLES)
   add_golden_test(TYPE abc2midi SAMPLE ${sample})
@@ -131,6 +132,32 @@ add_golden_test(
   NAME          abc2midi_pmar_demo_5
   TUNE          5
   ABC2MIDI_ARGS -PMAR
+)
+
+# Karaoke tune 5 rendered with -lyrics: the w: words come out as standard MIDI
+# Lyric (0x05) meta-events with bare syllables, and the Soft-Karaoke decoration
+# (@KMIDI KARAOKE FILE / @I header lines and the / \ line/paragraph prefixes) is
+# suppressed.  Contrast with abc2midi_demo_5, which pins the default 0x01 Text
+# karaoke rendering of the same tune.
+add_golden_test(
+  TYPE          abc2midi
+  SAMPLE        demo.abc
+  NAME          abc2midi_lyrics_demo_5
+  TUNE          5
+  ABC2MIDI_ARGS -lyrics
+)
+
+# words.abc rendered with -lyrics, the focused companion to the default 0x01
+# rendering pinned by abc2midi_words (registered above via EXTRA_SAMPLES).  The
+# diff between the two goldens is the -lyrics contract on a small controlled
+# input: 0x05 Lyric events with bare syllables, no @KMIDI/@I header, and no
+# / \ line/paragraph prefixes, while still exercising the w: control codes
+# (hyphen split, melisma _, hard space ~, blank *).
+add_golden_test(
+  TYPE          abc2midi
+  SAMPLE        words.abc
+  NAME          abc2midi_lyrics_words
+  ABC2MIDI_ARGS -lyrics
 )
 
 # Regression test for the -PMAR option (Part Marker meta-events).

--- a/tests/golden/abc2abc_words.txt
+++ b/tests/golden/abc2abc_words.txt
@@ -1,0 +1,18 @@
+% Lyric/word handling coverage for the golden test suite.
+% Small, deliberately exercises w: control codes: a hyphen-split word
+% (hy-phen), a melisma hold (_), a hard space joining two words into one
+% syllable (a~b), a blank syllable (*), and a line break between two w:
+% lines.  Rendered both with the default Soft-Karaoke output (0x01 Text,
+% with the / and \ line/paragraph prefixes) and with -lyrics (bare 0x05
+% Lyric events) so the contrast between the two is pinned.
+X:1
+T:Word and lyric handling
+C:abc2midi test
+M:4/4
+L:1/4
+Q:1/4=120
+K:C
+C D E F |
+w:plain hy-phen end
+G A B c |
+w:hold _ a~b *

--- a/tests/golden/abc2midi_lyrics_demo_5.txt
+++ b/tests/golden/abc2midi_lyrics_demo_5.txt
@@ -1,0 +1,610 @@
+Header format=1 ntrks=2 division=480
+Track start
+Time=0  Meta Text, type=0x03 (Sequence/Track Name)  leng=21
+     Text = <Oh You New York Girls>
+Time=0  Meta Text, type=0x01 (Text Event)  leng=10
+     Text = <note track>
+Time=0  Tempo, microseconds-per-MIDI-quarter-note=300000
+Time=0  Key signature, sharp/flats=0  minor=0
+Time=0  Time signature=4/4  MIDI-clocks/click=48  32nd-notes/24-MIDI-clocks=8
+Time=92185  Meta event, end of track
+Track end
+Track start
+Time=0  Meta Text, type=0x01 (Text Event)  leng=17
+     Text = <notes/lyric track>
+Time=0  Meta Text, type=0x01 (Text Event)  leng=3
+     Text = <X:5>
+Time=0  Meta Text, type=0x01 (Text Event)  leng=6
+     Text = <C:Trad>
+Time=0  Meta Text, type=0x01 (Text Event)  leng=9
+     Text = < 0 sharps>
+Time=1  Meta Text, type=0x05 (Lyric)  leng=2
+     Text = <As>
+Time=1  Note on, chan=1 pitch=79 vol=105
+Time=480  Note off, chan=1 pitch=79 vol=0
+Time=481  Meta Text, type=0x05 (Lyric)  leng=2
+     Text = < I>
+Time=481  Note on, chan=1 pitch=76 vol=105
+Time=960  Note off, chan=1 pitch=76 vol=0
+Time=961  Meta Text, type=0x05 (Lyric)  leng=7
+     Text = < walked>
+Time=961  Note on, chan=1 pitch=79 vol=80
+Time=1440  Note off, chan=1 pitch=79 vol=0
+Time=1441  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < out>
+Time=1441  Note on, chan=1 pitch=79 vol=95
+Time=2160  Note off, chan=1 pitch=79 vol=0
+Time=2161  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = < on>
+Time=2161  Note on, chan=1 pitch=79 vol=80
+Time=2400  Note off, chan=1 pitch=79 vol=0
+Time=2401  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = < So>
+Time=2401  Note on, chan=1 pitch=77 vol=105
+Time=2880  Note off, chan=1 pitch=77 vol=0
+Time=2881  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = <uth>
+Time=2881  Note on, chan=1 pitch=81 vol=80
+Time=3360  Note off, chan=1 pitch=81 vol=0
+Time=3361  Meta Text, type=0x05 (Lyric)  leng=8
+     Text = < Street,>
+Time=3361  Note on, chan=1 pitch=81 vol=95
+Time=4080  Note off, chan=1 pitch=81 vol=0
+Time=4081  Meta Text, type=0x05 (Lyric)  leng=2
+     Text = < a>
+Time=4081  Note on, chan=1 pitch=81 vol=80
+Time=4320  Note off, chan=1 pitch=81 vol=0
+Time=4321  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < fair>
+Time=4321  Note on, chan=1 pitch=79 vol=105
+Time=4800  Note off, chan=1 pitch=79 vol=0
+Time=4801  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < maid>
+Time=4801  Note on, chan=1 pitch=79 vol=80
+Time=5280  Note off, chan=1 pitch=79 vol=0
+Time=5281  Meta Text, type=0x05 (Lyric)  leng=2
+     Text = < I>
+Time=5281  Note on, chan=1 pitch=77 vol=95
+Time=5760  Note off, chan=1 pitch=77 vol=0
+Time=5761  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < did>
+Time=5761  Note on, chan=1 pitch=79 vol=80
+Time=6240  Note off, chan=1 pitch=79 vol=0
+Time=6241  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < meet>
+Time=6241  Note on, chan=1 pitch=76 vol=105
+Time=7680  Note off, chan=1 pitch=76 vol=0
+Time=7681  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < Who>
+Time=7681  Note on, chan=1 pitch=79 vol=80
+Time=8160  Note off, chan=1 pitch=79 vol=0
+Time=8161  Meta Text, type=0x05 (Lyric)  leng=6
+     Text = < asked>
+Time=8161  Note on, chan=1 pitch=84 vol=105
+Time=8880  Note off, chan=1 pitch=84 vol=0
+Time=8881  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = < me>
+Time=8881  Note on, chan=1 pitch=84 vol=80
+Time=9120  Note off, chan=1 pitch=84 vol=0
+Time=9121  Meta Text, type=0x05 (Lyric)  leng=7
+     Text = < please>
+Time=9121  Note on, chan=1 pitch=84 vol=95
+Time=9600  Note off, chan=1 pitch=84 vol=0
+Time=9601  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = < to>
+Time=9601  Note on, chan=1 pitch=79 vol=80
+Time=10080  Note off, chan=1 pitch=79 vol=0
+Time=10081  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < see>
+Time=10081  Note on, chan=1 pitch=83 vol=105
+Time=10560  Note off, chan=1 pitch=83 vol=0
+Time=10561  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < her>
+Time=10561  Note on, chan=1 pitch=81 vol=80
+Time=11040  Note off, chan=1 pitch=81 vol=0
+Time=11041  Meta Text, type=0x05 (Lyric)  leng=6
+     Text = < home,>
+Time=11041  Note on, chan=1 pitch=81 vol=95
+Time=11760  Note off, chan=1 pitch=81 vol=0
+Time=11761  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < she>
+Time=11761  Note on, chan=1 pitch=81 vol=80
+Time=12000  Note off, chan=1 pitch=81 vol=0
+Time=12001  Meta Text, type=0x05 (Lyric)  leng=6
+     Text = < lived>
+Time=12001  Note on, chan=1 pitch=79 vol=105
+Time=12720  Note off, chan=1 pitch=79 vol=0
+Time=12721  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = < on>
+Time=12721  Note on, chan=1 pitch=79 vol=80
+Time=12960  Note off, chan=1 pitch=79 vol=0
+Time=12961  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < Blee>
+Time=12961  Note on, chan=1 pitch=77 vol=95
+Time=13440  Note off, chan=1 pitch=77 vol=0
+Time=13441  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = <cker>
+Time=13441  Note on, chan=1 pitch=74 vol=80
+Time=13920  Note off, chan=1 pitch=74 vol=0
+Time=13921  Meta Text, type=0x05 (Lyric)  leng=7
+     Text = < Street>
+Time=13921  Note on, chan=1 pitch=72 vol=105
+Time=14880  Note off, chan=1 pitch=72 vol=0
+Time=14881  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < And>
+Time=14881  Note on, chan=1 pitch=76 vol=95
+Time=15360  Note off, chan=1 pitch=76 vol=0
+Time=15361  Meta Text, type=0x05 (Lyric)  leng=2
+     Text = < a>
+Time=15361  Note on, chan=1 pitch=77 vol=80
+Time=15840  Note off, chan=1 pitch=77 vol=0
+Time=15841  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = <way,>
+Time=15841  Note on, chan=1 pitch=79 vol=105
+Time=17280  Note off, chan=1 pitch=79 vol=0
+Time=17281  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < you>
+Time=17281  Note on, chan=1 pitch=76 vol=80
+Time=17760  Note off, chan=1 pitch=76 vol=0
+Time=17761  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < John>
+Time=17761  Note on, chan=1 pitch=77 vol=105
+Time=18240  Note off, chan=1 pitch=77 vol=0
+Time=18241  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = <ny,>
+Time=18241  Note on, chan=1 pitch=81 vol=80
+Time=19680  Note off, chan=1 pitch=81 vol=0
+Time=19681  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = < my>
+Time=19681  Note on, chan=1 pitch=83 vol=105
+Time=20640  Note off, chan=1 pitch=83 vol=0
+Time=20641  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < dear>
+Time=20641  Note on, chan=1 pitch=81 vol=95
+Time=21600  Note off, chan=1 pitch=81 vol=0
+Time=21601  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < hon>
+Time=21601  Note on, chan=1 pitch=81 vol=105
+Time=22080  Note off, chan=1 pitch=81 vol=0
+Time=22081  Meta Text, type=0x05 (Lyric)  leng=2
+     Text = <ey>
+Time=22081  Note on, chan=1 pitch=79 vol=80
+Time=23040  Note off, chan=1 pitch=79 vol=0
+Time=23521  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = < Oh>
+Time=23521  Note on, chan=1 pitch=84 vol=105
+Time=24960  Note off, chan=1 pitch=84 vol=0
+Time=24961  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < you>
+Time=24961  Note on, chan=1 pitch=83 vol=80
+Time=25440  Note off, chan=1 pitch=83 vol=0
+Time=25441  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < New>
+Time=25441  Note on, chan=1 pitch=83 vol=105
+Time=25920  Note off, chan=1 pitch=83 vol=0
+Time=25921  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < York>
+Time=25921  Note on, chan=1 pitch=81 vol=80
+Time=26400  Note off, chan=1 pitch=81 vol=0
+Time=26401  Meta Text, type=0x05 (Lyric)  leng=7
+     Text = < girls,>
+Time=26401  Note on, chan=1 pitch=81 vol=95
+Time=27360  Note off, chan=1 pitch=81 vol=0
+Time=27361  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < can>
+Time=27361  Note on, chan=1 pitch=79 vol=105
+Time=28080  Note off, chan=1 pitch=79 vol=0
+Time=28081  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < you>
+Time=28081  Note on, chan=1 pitch=79 vol=80
+Time=28320  Note off, chan=1 pitch=79 vol=0
+Time=28321  Meta Text, type=0x05 (Lyric)  leng=6
+     Text = < dance>
+Time=28321  Note on, chan=1 pitch=77 vol=95
+Time=28800  Note off, chan=1 pitch=77 vol=0
+Time=28801  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < the>
+Time=28801  Note on, chan=1 pitch=71 vol=80
+Time=29280  Note off, chan=1 pitch=71 vol=0
+Time=29281  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < pol>
+Time=29281  Note on, chan=1 pitch=74 vol=105
+Time=29760  Note off, chan=1 pitch=74 vol=0
+Time=29761  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = <ka?>
+Time=29761  Note on, chan=1 pitch=72 vol=80
+Time=30720  Note off, chan=1 pitch=72 vol=0
+Time=30721  Meta Text, type=0x05 (Lyric)  leng=2
+     Text = < I>
+Time=30721  Note on, chan=1 pitch=79 vol=80
+Time=31200  Note off, chan=1 pitch=79 vol=0
+Time=31201  Meta Text, type=0x05 (Lyric)  leng=6
+     Text = < said,>
+Time=31201  Note on, chan=1 pitch=76 vol=105
+Time=31680  Note off, chan=1 pitch=76 vol=0
+Time=31681  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < "My>
+Time=31681  Note on, chan=1 pitch=79 vol=80
+Time=32160  Note off, chan=1 pitch=79 vol=0
+Time=32161  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < dear>
+Time=32161  Note on, chan=1 pitch=79 vol=95
+Time=32880  Note off, chan=1 pitch=79 vol=0
+Time=32881  Meta Text, type=0x05 (Lyric)  leng=6
+     Text = < young>
+Time=32881  Note on, chan=1 pitch=79 vol=80
+Time=33120  Note off, chan=1 pitch=79 vol=0
+Time=33121  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = < la>
+Time=33121  Note on, chan=1 pitch=77 vol=105
+Time=33600  Note off, chan=1 pitch=77 vol=0
+Time=33601  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = <dy,>
+Time=33601  Note on, chan=1 pitch=81 vol=80
+Time=34080  Note off, chan=1 pitch=81 vol=0
+Time=34081  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < I'm>
+Time=34081  Note on, chan=1 pitch=81 vol=95
+Time=34800  Note off, chan=1 pitch=81 vol=0
+Time=34801  Meta Text, type=0x05 (Lyric)  leng=2
+     Text = < a>
+Time=34801  Note on, chan=1 pitch=81 vol=80
+Time=35040  Note off, chan=1 pitch=81 vol=0
+Time=35041  Meta Text, type=0x05 (Lyric)  leng=6
+     Text = < stran>
+Time=35041  Note on, chan=1 pitch=79 vol=105
+Time=35520  Note off, chan=1 pitch=79 vol=0
+Time=35521  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = <ger>
+Time=35521  Note on, chan=1 pitch=79 vol=80
+Time=36000  Note off, chan=1 pitch=79 vol=0
+Time=36001  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < here>
+Time=36001  Note on, chan=1 pitch=77 vol=95
+Time=36480  Note off, chan=1 pitch=77 vol=0
+Time=36481  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = < in>
+Time=36481  Note on, chan=1 pitch=79 vol=80
+Time=36960  Note off, chan=1 pitch=79 vol=0
+Time=36961  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < town>
+Time=36961  Note on, chan=1 pitch=76 vol=105
+Time=38400  Note off, chan=1 pitch=76 vol=0
+Time=38401  Meta Text, type=0x05 (Lyric)  leng=2
+     Text = < I>
+Time=38401  Note on, chan=1 pitch=79 vol=80
+Time=38880  Note off, chan=1 pitch=79 vol=0
+Time=38881  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < left>
+Time=38881  Note on, chan=1 pitch=84 vol=105
+Time=39600  Note off, chan=1 pitch=84 vol=0
+Time=39601  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = < my>
+Time=39601  Note on, chan=1 pitch=84 vol=80
+Time=39840  Note off, chan=1 pitch=84 vol=0
+Time=39841  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < ship>
+Time=39841  Note on, chan=1 pitch=84 vol=95
+Time=40320  Note off, chan=1 pitch=84 vol=0
+Time=40321  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < just>
+Time=40321  Note on, chan=1 pitch=79 vol=80
+Time=40800  Note off, chan=1 pitch=79 vol=0
+Time=40801  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < yes>
+Time=40801  Note on, chan=1 pitch=83 vol=105
+Time=41280  Note off, chan=1 pitch=83 vol=0
+Time=41281  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = <ter>
+Time=41281  Note on, chan=1 pitch=81 vol=80
+Time=41760  Note off, chan=1 pitch=81 vol=0
+Time=41761  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = <day,>
+Time=41761  Note on, chan=1 pitch=81 vol=95
+Time=42480  Note off, chan=1 pitch=81 vol=0
+Time=42481  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < from>
+Time=42481  Note on, chan=1 pitch=81 vol=80
+Time=42720  Note off, chan=1 pitch=81 vol=0
+Time=42721  Meta Text, type=0x05 (Lyric)  leng=6
+     Text = < Liver>
+Time=42721  Note on, chan=1 pitch=79 vol=105
+Time=43440  Note off, chan=1 pitch=79 vol=0
+Time=43441  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = <pool>
+Time=43441  Note on, chan=1 pitch=79 vol=80
+Time=43680  Note off, chan=1 pitch=79 vol=0
+Time=43681  Meta Text, type=0x05 (Lyric)  leng=2
+     Text = < I>
+Time=43681  Note on, chan=1 pitch=77 vol=95
+Time=44160  Note off, chan=1 pitch=77 vol=0
+Time=44161  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < was>
+Time=44161  Note on, chan=1 pitch=74 vol=80
+Time=44640  Note off, chan=1 pitch=74 vol=0
+Time=44641  Meta Text, type=0x05 (Lyric)  leng=8
+     Text = < bound.">
+Time=44641  Note on, chan=1 pitch=72 vol=105
+Time=45600  Note off, chan=1 pitch=72 vol=0
+Time=45601  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < And>
+Time=45601  Note on, chan=1 pitch=76 vol=95
+Time=46080  Note off, chan=1 pitch=76 vol=0
+Time=46081  Meta Text, type=0x05 (Lyric)  leng=2
+     Text = < a>
+Time=46081  Note on, chan=1 pitch=77 vol=80
+Time=46560  Note off, chan=1 pitch=77 vol=0
+Time=46561  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = <way,>
+Time=46561  Note on, chan=1 pitch=79 vol=105
+Time=48000  Note off, chan=1 pitch=79 vol=0
+Time=48001  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < you>
+Time=48001  Note on, chan=1 pitch=76 vol=80
+Time=48480  Note off, chan=1 pitch=76 vol=0
+Time=48481  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < John>
+Time=48481  Note on, chan=1 pitch=77 vol=105
+Time=48960  Note off, chan=1 pitch=77 vol=0
+Time=48961  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = <ny,>
+Time=48961  Note on, chan=1 pitch=81 vol=80
+Time=50400  Note off, chan=1 pitch=81 vol=0
+Time=50401  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = < my>
+Time=50401  Note on, chan=1 pitch=83 vol=105
+Time=51360  Note off, chan=1 pitch=83 vol=0
+Time=51361  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < dear>
+Time=51361  Note on, chan=1 pitch=81 vol=95
+Time=52320  Note off, chan=1 pitch=81 vol=0
+Time=52321  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < hon>
+Time=52321  Note on, chan=1 pitch=81 vol=105
+Time=52800  Note off, chan=1 pitch=81 vol=0
+Time=52801  Meta Text, type=0x05 (Lyric)  leng=2
+     Text = <ey>
+Time=52801  Note on, chan=1 pitch=79 vol=80
+Time=53760  Note off, chan=1 pitch=79 vol=0
+Time=54241  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = < Oh>
+Time=54241  Note on, chan=1 pitch=84 vol=105
+Time=55680  Note off, chan=1 pitch=84 vol=0
+Time=55681  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < you>
+Time=55681  Note on, chan=1 pitch=83 vol=80
+Time=56160  Note off, chan=1 pitch=83 vol=0
+Time=56161  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < New>
+Time=56161  Note on, chan=1 pitch=83 vol=105
+Time=56640  Note off, chan=1 pitch=83 vol=0
+Time=56641  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < York>
+Time=56641  Note on, chan=1 pitch=81 vol=80
+Time=57120  Note off, chan=1 pitch=81 vol=0
+Time=57121  Meta Text, type=0x05 (Lyric)  leng=7
+     Text = < girls,>
+Time=57121  Note on, chan=1 pitch=81 vol=95
+Time=58080  Note off, chan=1 pitch=81 vol=0
+Time=58081  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < can>
+Time=58081  Note on, chan=1 pitch=79 vol=105
+Time=58800  Note off, chan=1 pitch=79 vol=0
+Time=58801  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < you>
+Time=58801  Note on, chan=1 pitch=79 vol=80
+Time=59040  Note off, chan=1 pitch=79 vol=0
+Time=59041  Meta Text, type=0x05 (Lyric)  leng=6
+     Text = < dance>
+Time=59041  Note on, chan=1 pitch=77 vol=95
+Time=59520  Note off, chan=1 pitch=77 vol=0
+Time=59521  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < the>
+Time=59521  Note on, chan=1 pitch=71 vol=80
+Time=60000  Note off, chan=1 pitch=71 vol=0
+Time=60001  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < pol>
+Time=60001  Note on, chan=1 pitch=74 vol=105
+Time=60480  Note off, chan=1 pitch=74 vol=0
+Time=60481  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = <ka?>
+Time=60481  Note on, chan=1 pitch=72 vol=80
+Time=61440  Note off, chan=1 pitch=72 vol=0
+Time=61441  Meta Text, type=0x05 (Lyric)  leng=2
+     Text = < I>
+Time=61441  Note on, chan=1 pitch=79 vol=80
+Time=61920  Note off, chan=1 pitch=79 vol=0
+Time=61921  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < took>
+Time=61921  Note on, chan=1 pitch=76 vol=105
+Time=62400  Note off, chan=1 pitch=76 vol=0
+Time=62401  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < her>
+Time=62401  Note on, chan=1 pitch=79 vol=80
+Time=62880  Note off, chan=1 pitch=79 vol=0
+Time=62881  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < out>
+Time=62881  Note on, chan=1 pitch=79 vol=95
+Time=63600  Note off, chan=1 pitch=79 vol=0
+Time=63601  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = < to>
+Time=63601  Note on, chan=1 pitch=79 vol=80
+Time=63840  Note off, chan=1 pitch=79 vol=0
+Time=63841  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < Tiff>
+Time=63841  Note on, chan=1 pitch=77 vol=105
+Time=64320  Note off, chan=1 pitch=77 vol=0
+Time=64321  Meta Text, type=0x05 (Lyric)  leng=2
+     Text = <an>
+Time=64321  Note on, chan=1 pitch=81 vol=80
+Time=64800  Note off, chan=1 pitch=81 vol=0
+Time=64801  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = <y's,>
+Time=64801  Note on, chan=1 pitch=81 vol=95
+Time=65520  Note off, chan=1 pitch=81 vol=0
+Time=65521  Meta Text, type=0x05 (Lyric)  leng=2
+     Text = < I>
+Time=65521  Note on, chan=1 pitch=81 vol=80
+Time=65760  Note off, chan=1 pitch=81 vol=0
+Time=65761  Meta Text, type=0x05 (Lyric)  leng=7
+     Text = < spared>
+Time=65761  Note on, chan=1 pitch=79 vol=105
+Time=66240  Note off, chan=1 pitch=79 vol=0
+Time=66241  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < her>
+Time=66241  Note on, chan=1 pitch=79 vol=80
+Time=66720  Note off, chan=1 pitch=79 vol=0
+Time=66721  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = < no>
+Time=66721  Note on, chan=1 pitch=77 vol=95
+Time=67200  Note off, chan=1 pitch=77 vol=0
+Time=67201  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = < ex>
+Time=67201  Note on, chan=1 pitch=79 vol=80
+Time=67680  Note off, chan=1 pitch=79 vol=0
+Time=67681  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = <pense>
+Time=67681  Note on, chan=1 pitch=76 vol=105
+Time=69120  Note off, chan=1 pitch=76 vol=0
+Time=69121  Meta Text, type=0x05 (Lyric)  leng=2
+     Text = < I>
+Time=69121  Note on, chan=1 pitch=79 vol=80
+Time=69600  Note off, chan=1 pitch=79 vol=0
+Time=69601  Meta Text, type=0x05 (Lyric)  leng=7
+     Text = < bought>
+Time=69601  Note on, chan=1 pitch=84 vol=105
+Time=70320  Note off, chan=1 pitch=84 vol=0
+Time=70321  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < her>
+Time=70321  Note on, chan=1 pitch=84 vol=80
+Time=70560  Note off, chan=1 pitch=84 vol=0
+Time=70561  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < two>
+Time=70561  Note on, chan=1 pitch=84 vol=95
+Time=71040  Note off, chan=1 pitch=84 vol=0
+Time=71041  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < gold>
+Time=71041  Note on, chan=1 pitch=79 vol=80
+Time=71520  Note off, chan=1 pitch=79 vol=0
+Time=71521  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = < ea>
+Time=71521  Note on, chan=1 pitch=83 vol=105
+Time=72000  Note off, chan=1 pitch=83 vol=0
+Time=72001  Meta Text, type=0x05 (Lyric)  leng=1
+     Text = <r>
+Time=72001  Note on, chan=1 pitch=81 vol=80
+Time=72480  Note off, chan=1 pitch=81 vol=0
+Time=72481  Meta Text, type=0x05 (Lyric)  leng=6
+     Text = <rings,>
+Time=72481  Note on, chan=1 pitch=81 vol=95
+Time=73200  Note off, chan=1 pitch=81 vol=0
+Time=73201  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < they>
+Time=73201  Note on, chan=1 pitch=81 vol=80
+Time=73440  Note off, chan=1 pitch=81 vol=0
+Time=73441  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < cost>
+Time=73441  Note on, chan=1 pitch=79 vol=105
+Time=74160  Note off, chan=1 pitch=79 vol=0
+Time=74161  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = < me>
+Time=74161  Note on, chan=1 pitch=79 vol=80
+Time=74400  Note off, chan=1 pitch=79 vol=0
+Time=74401  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < fif>
+Time=74401  Note on, chan=1 pitch=77 vol=95
+Time=74880  Note off, chan=1 pitch=77 vol=0
+Time=74881  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = <teen>
+Time=74881  Note on, chan=1 pitch=74 vol=80
+Time=75360  Note off, chan=1 pitch=74 vol=0
+Time=75361  Meta Text, type=0x05 (Lyric)  leng=7
+     Text = < cents.>
+Time=75361  Note on, chan=1 pitch=72 vol=105
+Time=76320  Note off, chan=1 pitch=72 vol=0
+Time=76321  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < And>
+Time=76321  Note on, chan=1 pitch=76 vol=95
+Time=76800  Note off, chan=1 pitch=76 vol=0
+Time=76801  Meta Text, type=0x05 (Lyric)  leng=2
+     Text = < a>
+Time=76801  Note on, chan=1 pitch=77 vol=80
+Time=77280  Note off, chan=1 pitch=77 vol=0
+Time=77281  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = <way,>
+Time=77281  Note on, chan=1 pitch=79 vol=105
+Time=78720  Note off, chan=1 pitch=79 vol=0
+Time=78721  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < you>
+Time=78721  Note on, chan=1 pitch=76 vol=80
+Time=79200  Note off, chan=1 pitch=76 vol=0
+Time=79201  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < John>
+Time=79201  Note on, chan=1 pitch=77 vol=105
+Time=79680  Note off, chan=1 pitch=77 vol=0
+Time=79681  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = <ny,>
+Time=79681  Note on, chan=1 pitch=81 vol=80
+Time=81120  Note off, chan=1 pitch=81 vol=0
+Time=81121  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = < my>
+Time=81121  Note on, chan=1 pitch=83 vol=105
+Time=82080  Note off, chan=1 pitch=83 vol=0
+Time=82081  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < dear>
+Time=82081  Note on, chan=1 pitch=81 vol=95
+Time=83040  Note off, chan=1 pitch=81 vol=0
+Time=83041  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < hon>
+Time=83041  Note on, chan=1 pitch=81 vol=105
+Time=83520  Note off, chan=1 pitch=81 vol=0
+Time=83521  Meta Text, type=0x05 (Lyric)  leng=2
+     Text = <ey>
+Time=83521  Note on, chan=1 pitch=79 vol=80
+Time=84480  Note off, chan=1 pitch=79 vol=0
+Time=84961  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = < Oh>
+Time=84961  Note on, chan=1 pitch=84 vol=105
+Time=86400  Note off, chan=1 pitch=84 vol=0
+Time=86401  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < you>
+Time=86401  Note on, chan=1 pitch=83 vol=80
+Time=86880  Note off, chan=1 pitch=83 vol=0
+Time=86881  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < New>
+Time=86881  Note on, chan=1 pitch=83 vol=105
+Time=87360  Note off, chan=1 pitch=83 vol=0
+Time=87361  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < York>
+Time=87361  Note on, chan=1 pitch=81 vol=80
+Time=87840  Note off, chan=1 pitch=81 vol=0
+Time=87841  Meta Text, type=0x05 (Lyric)  leng=7
+     Text = < girls,>
+Time=87841  Note on, chan=1 pitch=81 vol=95
+Time=88800  Note off, chan=1 pitch=81 vol=0
+Time=88801  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < can>
+Time=88801  Note on, chan=1 pitch=79 vol=105
+Time=89520  Note off, chan=1 pitch=79 vol=0
+Time=89521  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < you>
+Time=89521  Note on, chan=1 pitch=79 vol=80
+Time=89760  Note off, chan=1 pitch=79 vol=0
+Time=89761  Meta Text, type=0x05 (Lyric)  leng=6
+     Text = < dance>
+Time=89761  Note on, chan=1 pitch=77 vol=95
+Time=90240  Note off, chan=1 pitch=77 vol=0
+Time=90241  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < the>
+Time=90241  Note on, chan=1 pitch=71 vol=80
+Time=90720  Note off, chan=1 pitch=71 vol=0
+Time=90721  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < pol>
+Time=90721  Note on, chan=1 pitch=74 vol=105
+Time=91200  Note off, chan=1 pitch=74 vol=0
+Time=91201  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = <ka?>
+Time=91201  Note on, chan=1 pitch=72 vol=80
+Time=92160  Note off, chan=1 pitch=72 vol=0
+Time=92186  Meta event, end of track
+Track end

--- a/tests/golden/abc2midi_lyrics_words.txt
+++ b/tests/golden/abc2midi_lyrics_words.txt
@@ -1,0 +1,50 @@
+Header format=1 ntrks=2 division=480
+Track start
+Time=0  Meta Text, type=0x03 (Sequence/Track Name)  leng=23
+     Text = <Word and lyric handling>
+Time=0  Meta Text, type=0x01 (Text Event)  leng=10
+     Text = <note track>
+Time=0  Tempo, microseconds-per-MIDI-quarter-note=500000
+Time=0  Key signature, sharp/flats=0  minor=0
+Time=0  Time signature=4/4  MIDI-clocks/click=48  32nd-notes/24-MIDI-clocks=8
+Time=3866  Meta event, end of track
+Track end
+Track start
+Time=0  Meta Text, type=0x01 (Text Event)  leng=17
+     Text = <notes/lyric track>
+Time=0  Meta Text, type=0x01 (Text Event)  leng=3
+     Text = <X:1>
+Time=0  Meta Text, type=0x01 (Text Event)  leng=15
+     Text = <C:abc2midi test>
+Time=1  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = <plain>
+Time=1  Note on, chan=1 pitch=60 vol=105
+Time=480  Note off, chan=1 pitch=60 vol=0
+Time=481  Meta Text, type=0x05 (Lyric)  leng=3
+     Text = < hy>
+Time=481  Note on, chan=1 pitch=62 vol=80
+Time=960  Note off, chan=1 pitch=62 vol=0
+Time=961  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = <phen>
+Time=961  Note on, chan=1 pitch=64 vol=95
+Time=1440  Note off, chan=1 pitch=64 vol=0
+Time=1441  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < end>
+Time=1441  Note on, chan=1 pitch=65 vol=80
+Time=1920  Note off, chan=1 pitch=65 vol=0
+Time=1921  Meta Text, type=0x05 (Lyric)  leng=5
+     Text = < hold>
+Time=1921  Note on, chan=1 pitch=67 vol=105
+Time=2400  Note off, chan=1 pitch=67 vol=0
+Time=2401  Note on, chan=1 pitch=69 vol=80
+Time=2880  Note off, chan=1 pitch=69 vol=0
+Time=2881  Meta Text, type=0x05 (Lyric)  leng=4
+     Text = < a b>
+Time=2881  Note on, chan=1 pitch=71 vol=95
+Time=3360  Note off, chan=1 pitch=71 vol=0
+Time=3361  Meta Text, type=0x05 (Lyric)  leng=1
+     Text = < >
+Time=3361  Note on, chan=1 pitch=72 vol=80
+Time=3840  Note off, chan=1 pitch=72 vol=0
+Time=3866  Meta event, end of track
+Track end

--- a/tests/golden/abc2midi_words.txt
+++ b/tests/golden/abc2midi_words.txt
@@ -1,0 +1,56 @@
+Header format=1 ntrks=2 division=480
+Track start
+Time=1  Meta Text, type=0x01 (Text Event)  leng=19
+     Text = <@KMIDI KARAOKE FILE>
+Time=1  Meta Text, type=0x03 (Sequence/Track Name)  leng=23
+     Text = <Word and lyric handling>
+Time=1  Meta Text, type=0x01 (Text Event)  leng=25
+     Text = <@IWord and lyric handling>
+Time=1  Meta Text, type=0x01 (Text Event)  leng=15
+     Text = <@Iabc2midi test>
+Time=1  Meta Text, type=0x01 (Text Event)  leng=10
+     Text = <note track>
+Time=1  Tempo, microseconds-per-MIDI-quarter-note=500000
+Time=1  Key signature, sharp/flats=0  minor=0
+Time=1  Time signature=4/4  MIDI-clocks/click=48  32nd-notes/24-MIDI-clocks=8
+Time=3866  Meta event, end of track
+Track end
+Track start
+Time=0  Meta Text, type=0x01 (Text Event)  leng=17
+     Text = <notes/lyric track>
+Time=0  Meta Text, type=0x01 (Text Event)  leng=3
+     Text = <X:1>
+Time=0  Meta Text, type=0x01 (Text Event)  leng=15
+     Text = <C:abc2midi test>
+Time=1  Meta Text, type=0x01 (Text Event)  leng=6
+     Text = </plain>
+Time=1  Note on, chan=1 pitch=60 vol=105
+Time=480  Note off, chan=1 pitch=60 vol=0
+Time=481  Meta Text, type=0x01 (Text Event)  leng=3
+     Text = < hy>
+Time=481  Note on, chan=1 pitch=62 vol=80
+Time=960  Note off, chan=1 pitch=62 vol=0
+Time=961  Meta Text, type=0x01 (Text Event)  leng=4
+     Text = <phen>
+Time=961  Note on, chan=1 pitch=64 vol=95
+Time=1440  Note off, chan=1 pitch=64 vol=0
+Time=1441  Meta Text, type=0x01 (Text Event)  leng=4
+     Text = < end>
+Time=1441  Note on, chan=1 pitch=65 vol=80
+Time=1920  Note off, chan=1 pitch=65 vol=0
+Time=1921  Meta Text, type=0x01 (Text Event)  leng=6
+     Text = <\ hold>
+Time=1921  Note on, chan=1 pitch=67 vol=105
+Time=2400  Note off, chan=1 pitch=67 vol=0
+Time=2401  Note on, chan=1 pitch=69 vol=80
+Time=2880  Note off, chan=1 pitch=69 vol=0
+Time=2881  Meta Text, type=0x01 (Text Event)  leng=4
+     Text = < a b>
+Time=2881  Note on, chan=1 pitch=71 vol=95
+Time=3360  Note off, chan=1 pitch=71 vol=0
+Time=3361  Meta Text, type=0x01 (Text Event)  leng=1
+     Text = < >
+Time=3361  Note on, chan=1 pitch=72 vol=80
+Time=3840  Note off, chan=1 pitch=72 vol=0
+Time=3866  Meta event, end of track
+Track end


### PR DESCRIPTION
## Summary

Adds a `-lyrics` option to abc2midi that emits the `w:` words as standard
**MIDI Lyric (0x05)** meta-events instead of the default Soft-Karaoke
rendering.

When a tune has `w:` word lines, abc2midi renders them in the Soft-Karaoke
convention: `0x01` Text meta-events, an `@KMIDI KARAOKE FILE` / `@I` header on
the conductor track, and a `/` or `\` line/paragraph prefix on the first
syllable of each `w:` line. Players that follow the General MIDI Lyric (`0x05`)
meta-event convention instead see no lyrics at all.

With `-lyrics` the words come out as standard `0x05` Lyric meta-events carrying
just the bare syllable text, still synchronized to their notes, with the
karaoke-specific decoration suppressed (the standard sequence-name title is
kept). **Default behaviour is unchanged.**

## Example

`abc2midi demo.abc 5 -lyrics` on the karaoke tune "Oh You New York Girls":

| | default | `-lyrics` |
|---|---|---|
| syllable event | `0x01 (Text Event)` | `0x05 (Lyric)` |
| first syllable | `</As>` | `<As>` |
| track-0 header | `@KMIDI KARAOKE FILE`, `@I…` | *(none; title kept)* |
| word spacing | `< walked>` | `< walked>` |
| note timing | unchanged | unchanged |

## Implementation

- `genmidi.c`: new `word_data()` helper picks `lyric` (0x05) vs `text_event`
  (0x01) based on a `lyrics_meta` flag; `lyrics_meta` guards skip the `/` and
  `\` prefixes in `getword()` and the `@KMIDI`/`@I` header lines in
  `karaokestarttrack()`.
- `store.c`: define `lyrics_meta`, parse `-lyrics`, document it in `-h`.
- `doc/abc2midi.1`, `doc/CHANGES`: document the option.

## Tests

Two layers of golden coverage (CMake/CTest suite under `tests/`):

- `abc2midi_lyrics_demo_5` — pins `-lyrics` on a real karaoke tune (demo.abc
  tune 5): 147 Lyric events, no `@KMIDI`/`@I`, no `/` `\` prefixes.
- new `samples/words.abc` is a small controlled input pinned **both ways** —
  `abc2midi_words` (default 0x01 Soft-Karaoke) and `abc2midi_lyrics_words`
  (`-lyrics` 0x05). The diff between the two goldens is the option's contract,
  and the input exercises the `w:` control codes (hyphen split, melisma `_`,
  hard space `~`, blank `*`) and line/paragraph prefixes that the demo tune
  does not.

Full suite passes (46/46) and the default-rendering goldens are byte-identical,
confirming no change to existing behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
