### PR TITLE
Fix LTO type-mismatch on controlnvals array bound (#9)

### DIFF
--- a/genmidi.c
+++ b/genmidi.c
@@ -258,8 +258,7 @@ int benddata[256];
 int bendnvals;
 int bendtype = 1;
 
-/* [SS] 2015-07-24 2015-10-03 */
-#define MAXLAYERS 3
+/* [SS] 2015-07-24 2015-10-03; MAXLAYERS now defined in genmidi.h */
 int controldata[MAXLAYERS][256];
 int controlnvals[MAXLAYERS];
 int controldefaults[128]; /* [SS] 2015-08-10 */

--- a/genmidi.h
+++ b/genmidi.h
@@ -37,3 +37,4 @@ struct trackstruct {enum {NOTES, WORDS, NOTEWORDS, GCHORDS, DRUMS, DRONE} trackt
 #define DIV 480
 #define MAXPARTS 100
 #define MAXCHORDNAMES 80
+#define MAXLAYERS 3 /* [SS] 2015-07-24 2015-10-03; shared with queues.c */

--- a/queues.c
+++ b/queues.c
@@ -61,8 +61,8 @@ extern int bendstate; /* from genmidi.c [SS] */
 /* [SS] 2014-09-10 */
 extern int benddata[256]; /* from genmidi.c [SS] 2015-09-10 2015-10-03 */
 extern int bendnvals;
-extern int controldata[3][256]; /* extended to 256 2015-10-03 */
-extern int controlnvals[2];
+extern int controldata[MAXLAYERS][256]; /* extended to 256 2015-10-03 */
+extern int controlnvals[MAXLAYERS];
 extern int controldefaults[128]; /* [SS] 2015-08-10 */
 extern int nlayers; /* [SS] 2015-08-20 */
 


### PR DESCRIPTION
## Summary

Fixes #9 — building `abc2midi` with `-flto -Werror=lto-type-mismatch` fails because the `controlnvals` array is declared with two different bounds in two translation units:

- `genmidi.c` **defines** it as `int controlnvals[MAXLAYERS];` (`MAXLAYERS == 3`)
- `queues.c` **declares** it as `extern int controlnvals[2];`

GCC's LTO type checker rightly flags the disagreement, and with `-Werror=lto-type-mismatch` (as used in the Gentoo build, https://bugs.gentoo.org/876421) it becomes fatal.

## This is a real bug, not just a cosmetic LTO complaint

`note_effect5()` in `queues.c` loops:

```c
for (layer = 0; layer <= nlayers; layer++)
    if (controlnvals[layer] > 1) { ... }
```

`nlayers` can reach `MAXLAYERS - 1 == 2`, so the code reads `controlnvals[2]` — past the `[2]` bound the extern declares. The backing storage is size 3 so it doesn't corrupt memory at runtime, but the declaration is simply wrong.

## Fix

Define `MAXLAYERS` once in `genmidi.h` (alongside `DIV`/`MAXPARTS`/`MAXCHORDNAMES`), and use the symbol for both the definition in `genmidi.c` and the extern declarations in `queues.c`. The companion `extern int controldata[3][256]` is made symbolic too (it was numerically correct but had the same latent coupling). Now the two translation units cannot drift apart.

## Testing

- Normal `make abc2midi`: clean build, binary runs.
- `make abc2midi CFLAGS="... -flto -Werror=lto-type-mismatch" LDFLAGS="-flto -Werror=lto-type-mismatch -lm"`: the `controlnvals` type-mismatch error is gone and the binary links cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)