### PR TITLE
mftext: fix swapped lsb/msb labels in Pitchbend text output

### DIFF
--- a/doc/CHANGES
+++ b/doc/CHANGES
@@ -15749,3 +15749,13 @@ releases such as the 3.22.1 shipped by Ubuntu 22.04 LTS can use
 "cmake --preset" without hitting "Unrecognized 'version' field".  No
 v4/v5/v6 schema features were in use; v3 covers every field present
 in the file.
+
+June 17 2026 [RK]
+
+mftext: fixed the Pitchbend text output, which printed its two data
+bytes under swapped "lsb="/"msb=" labels (sshlien/abcmidi#6).  The
+values now match their labels and are shown most-significant first
+("msb=%d lsb=%d") since the bend value is msb*128 + lsb.  This is a
+display-only change in the text dump; MIDI output is unaffected.  The
+golden test references that recorded the old mislabeled lines were
+regenerated to match.

--- a/mftext.c
+++ b/mftext.c
@@ -123,6 +123,9 @@ void txt_parameter(int chan, int control, int value)
 
 
 /* [SS] 2017-11-16 submitted by Jonathan Hough (msb,lsb interchanged) */
+/* [RK] 2026-06-17 the lsb/msb values were printed under swapped labels;
+   fixed and reordered to msb-first since the bend is msb*128 + lsb
+   (sshlien/abcmidi#6) */
 void txt_pitchbend(int chan, int lsb, int msb)
 {
   prtime();

--- a/mftext.c
+++ b/mftext.c
@@ -126,7 +126,7 @@ void txt_parameter(int chan, int control, int value)
 void txt_pitchbend(int chan, int lsb, int msb)
 {
   prtime();
-  printf("Pitchbend, chan=%d lsb=%d msb=%d\n",chan+1,msb,lsb);
+  printf("Pitchbend, chan=%d msb=%d lsb=%d\n",chan+1,msb,lsb);
 }
 
 void txt_program(int chan, int program)

--- a/tests/golden/abc2midi_daramud.txt
+++ b/tests/golden/abc2midi_daramud.txt
@@ -16,18 +16,18 @@ Time=0  Meta Text, type=0x01 (Text Event)  leng=68
 Time=1  Program, chan=1 program=111
 Time=1  Note on, chan=1 pitch=74 vol=105
 Time=240  Note off, chan=1 pitch=74 vol=0
-Time=241  Pitchbend, chan=1 lsb=48 msb=0
+Time=241  Pitchbend, chan=1 msb=48 lsb=0
 Time=241  Note on, chan=1 pitch=76 vol=80
 Time=480  Note off, chan=1 pitch=76 vol=0
-Time=481  Pitchbend, chan=1 lsb=64 msb=0
+Time=481  Pitchbend, chan=1 msb=64 lsb=0
 Time=481  Note on, chan=1 pitch=79 vol=80
 Time=720  Note off, chan=1 pitch=79 vol=0
 Time=721  Note on, chan=1 pitch=77 vol=80
 Time=960  Note off, chan=1 pitch=77 vol=0
-Time=961  Pitchbend, chan=1 lsb=48 msb=0
+Time=961  Pitchbend, chan=1 msb=48 lsb=0
 Time=961  Note on, chan=1 pitch=76 vol=95
 Time=1200  Note off, chan=1 pitch=76 vol=0
-Time=1201  Pitchbend, chan=1 lsb=64 msb=0
+Time=1201  Pitchbend, chan=1 msb=64 lsb=0
 Time=1201  Note on, chan=1 pitch=74 vol=80
 Time=1440  Note off, chan=1 pitch=74 vol=0
 Time=1441  Note on, chan=1 pitch=72 vol=80
@@ -64,16 +64,16 @@ Time=5281  Note on, chan=1 pitch=67 vol=80
 Time=5520  Note off, chan=1 pitch=67 vol=0
 Time=5521  Note on, chan=1 pitch=65 vol=80
 Time=5760  Note off, chan=1 pitch=65 vol=0
-Time=5761  Pitchbend, chan=1 lsb=48 msb=0
+Time=5761  Pitchbend, chan=1 msb=48 lsb=0
 Time=5761  Note on, chan=1 pitch=64 vol=80
 Time=6000  Note off, chan=1 pitch=64 vol=0
-Time=6001  Pitchbend, chan=1 lsb=64 msb=0
+Time=6001  Pitchbend, chan=1 msb=64 lsb=0
 Time=6001  Note on, chan=1 pitch=62 vol=95
 Time=6240  Note off, chan=1 pitch=62 vol=0
-Time=6241  Pitchbend, chan=1 lsb=48 msb=0
+Time=6241  Pitchbend, chan=1 msb=48 lsb=0
 Time=6241  Note on, chan=1 pitch=64 vol=80
 Time=6480  Note off, chan=1 pitch=64 vol=0
-Time=6481  Pitchbend, chan=1 lsb=64 msb=0
+Time=6481  Pitchbend, chan=1 msb=64 lsb=0
 Time=6481  Note on, chan=1 pitch=65 vol=80
 Time=6720  Note off, chan=1 pitch=65 vol=0
 Time=6721  Note on, chan=1 pitch=67 vol=80
@@ -102,22 +102,22 @@ Time=10081  Note on, chan=1 pitch=67 vol=80
 Time=10560  Note off, chan=1 pitch=67 vol=0
 Time=10561  Note on, chan=1 pitch=65 vol=80
 Time=10620  Note off, chan=1 pitch=65 vol=0
-Time=10621  Pitchbend, chan=1 lsb=48 msb=0
+Time=10621  Pitchbend, chan=1 msb=48 lsb=0
 Time=10621  Note on, chan=1 pitch=64 vol=80
 Time=10800  Note off, chan=1 pitch=64 vol=0
 Time=10801  Note on, chan=1 pitch=64 vol=95
 Time=11040  Note off, chan=1 pitch=64 vol=0
 Time=11041  Note on, chan=1 pitch=64 vol=80
 Time=11280  Note off, chan=1 pitch=64 vol=0
-Time=11281  Pitchbend, chan=1 lsb=64 msb=0
+Time=11281  Pitchbend, chan=1 msb=64 lsb=0
 Time=11281  Note on, chan=1 pitch=67 vol=80
 Time=11760  Note off, chan=1 pitch=67 vol=0
 Time=11761  Note on, chan=1 pitch=65 vol=95
 Time=12240  Note off, chan=1 pitch=65 vol=0
-Time=12241  Pitchbend, chan=1 lsb=48 msb=0
+Time=12241  Pitchbend, chan=1 msb=48 lsb=0
 Time=12241  Note on, chan=1 pitch=64 vol=80
 Time=12300  Note off, chan=1 pitch=64 vol=0
-Time=12301  Pitchbend, chan=1 lsb=64 msb=0
+Time=12301  Pitchbend, chan=1 msb=64 lsb=0
 Time=12301  Note on, chan=1 pitch=62 vol=80
 Time=12480  Note off, chan=1 pitch=62 vol=0
 Time=12481  Note on, chan=1 pitch=62 vol=80
@@ -126,7 +126,7 @@ Time=12721  Note on, chan=1 pitch=62 vol=95
 Time=12960  Note off, chan=1 pitch=62 vol=0
 Time=12961  Note on, chan=1 pitch=65 vol=80
 Time=13440  Note off, chan=1 pitch=65 vol=0
-Time=13441  Pitchbend, chan=1 lsb=48 msb=0
+Time=13441  Pitchbend, chan=1 msb=48 lsb=0
 Time=13441  Note on, chan=1 pitch=64 vol=80
 Time=13920  Note off, chan=1 pitch=64 vol=0
 Time=13946  Meta event, end of track

--- a/tests/golden/abc2midi_demo_11.txt
+++ b/tests/golden/abc2midi_demo_11.txt
@@ -29,16 +29,16 @@ Time=0  Meta Text, type=0x01 (Text Event)  leng=66
 Time=0  Meta Text, type=0x01 (Text Event)  leng=54
      Text = < %MIDI temperamentnormal                      % 12-EDO>
 Time=1  Program, chan=1 program=16
-Time=1  Pitchbend, chan=1 lsb=62 msb=16
+Time=1  Pitchbend, chan=1 msb=62 lsb=16
 Time=1  Note on, chan=1 pitch=72 vol=105
 Time=960  Note off, chan=1 pitch=72 vol=0
-Time=961  Pitchbend, chan=1 lsb=65 msb=32
+Time=961  Pitchbend, chan=1 msb=65 lsb=32
 Time=961  Note on, chan=1 pitch=71 vol=95
 Time=1920  Note off, chan=1 pitch=71 vol=0
-Time=1921  Pitchbend, chan=1 lsb=62 msb=16
+Time=1921  Pitchbend, chan=1 msb=62 lsb=16
 Time=1921  Note on, chan=1 pitch=72 vol=105
 Time=2640  Note off, chan=1 pitch=72 vol=0
-Time=2881  Pitchbend, chan=1 lsb=68 msb=49
+Time=2881  Pitchbend, chan=1 msb=68 lsb=49
 Time=2881  Note on, chan=1 pitch=70 vol=95
 Time=3840  Note off, chan=1 pitch=70 vol=0
 Time=3866  Meta event, end of track
@@ -47,7 +47,7 @@ Track start
 Time=0  Meta Text, type=0x01 (Text Event)  leng=10
      Text = <note track>
 Time=1  Program, chan=2 program=16
-Time=1  Pitchbend, chan=2 lsb=62 msb=96
+Time=1  Pitchbend, chan=2 msb=62 lsb=96
 Time=1  Note on, chan=2 pitch=67 vol=105
 Time=960  Note off, chan=2 pitch=67 vol=0
 Time=961  Note on, chan=2 pitch=67 vol=95
@@ -62,25 +62,25 @@ Track start
 Time=0  Meta Text, type=0x01 (Text Event)  leng=10
      Text = <note track>
 Time=1  Program, chan=3 program=16
-Time=1  Pitchbend, chan=3 lsb=64 msb=80
+Time=1  Pitchbend, chan=3 msb=64 lsb=80
 Time=1  Note on, chan=3 pitch=64 vol=105
 Time=320  Note off, chan=3 pitch=64 vol=0
-Time=321  Pitchbend, chan=3 lsb=60 msb=32
+Time=321  Pitchbend, chan=3 msb=60 lsb=32
 Time=321  Note on, chan=3 pitch=63 vol=80
 Time=640  Note off, chan=3 pitch=63 vol=0
-Time=641  Pitchbend, chan=3 lsb=67 msb=96
+Time=641  Pitchbend, chan=3 msb=67 lsb=96
 Time=641  Note on, chan=3 pitch=63 vol=80
 Time=960  Note off, chan=3 pitch=63 vol=0
-Time=961  Pitchbend, chan=3 lsb=63 msb=48
+Time=961  Pitchbend, chan=3 msb=63 lsb=48
 Time=961  Note on, chan=3 pitch=62 vol=95
 Time=1280  Note off, chan=3 pitch=62 vol=0
-Time=1281  Pitchbend, chan=3 lsb=61 msb=64
+Time=1281  Pitchbend, chan=3 msb=61 lsb=64
 Time=1281  Note on, chan=3 pitch=65 vol=80
 Time=1600  Note off, chan=3 pitch=65 vol=0
-Time=1601  Pitchbend, chan=3 lsb=57 msb=15
+Time=1601  Pitchbend, chan=3 msb=57 lsb=15
 Time=1601  Note on, chan=3 pitch=64 vol=80
 Time=1920  Note off, chan=3 pitch=64 vol=0
-Time=1921  Pitchbend, chan=3 lsb=64 msb=80
+Time=1921  Pitchbend, chan=3 msb=64 lsb=80
 Time=1921  Note on, chan=3 pitch=64 vol=105
 Time=2640  Note off, chan=3 pitch=64 vol=0
 Time=2881  Note on, chan=3 pitch=64 vol=95
@@ -91,13 +91,13 @@ Track start
 Time=0  Meta Text, type=0x01 (Text Event)  leng=10
      Text = <note track>
 Time=1  Program, chan=4 program=16
-Time=1  Pitchbend, chan=4 lsb=62 msb=16
+Time=1  Pitchbend, chan=4 msb=62 lsb=16
 Time=1  Note on, chan=4 pitch=60 vol=105
 Time=960  Note off, chan=4 pitch=60 vol=0
-Time=961  Pitchbend, chan=4 lsb=62 msb=96
+Time=961  Pitchbend, chan=4 msb=62 lsb=96
 Time=961  Note on, chan=4 pitch=55 vol=95
 Time=1920  Note off, chan=4 pitch=55 vol=0
-Time=1921  Pitchbend, chan=4 lsb=62 msb=16
+Time=1921  Pitchbend, chan=4 msb=62 lsb=16
 Time=1921  Note on, chan=4 pitch=60 vol=105
 Time=2640  Note off, chan=4 pitch=60 vol=0
 Time=2881  Note on, chan=4 pitch=60 vol=95

--- a/tests/golden/abc2midi_detune.txt
+++ b/tests/golden/abc2midi_detune.txt
@@ -11,146 +11,146 @@ Time=0  Meta Text, type=0x03 (Sequence/Track Name)  leng=19
      Text = <temperament command>
 Time=1  Note on, chan=1 pitch=72 vol=105
 Time=240  Note off, chan=1 pitch=72 vol=0
-Time=241  Pitchbend, chan=1 lsb=62 msb=93
+Time=241  Pitchbend, chan=1 msb=62 lsb=93
 Time=241  Note on, chan=1 pitch=74 vol=80
 Time=480  Note off, chan=1 pitch=74 vol=0
-Time=481  Pitchbend, chan=1 lsb=61 msb=57
+Time=481  Pitchbend, chan=1 msb=61 lsb=57
 Time=481  Note on, chan=1 pitch=76 vol=80
 Time=720  Note off, chan=1 pitch=76 vol=0
-Time=721  Pitchbend, chan=1 lsb=64 msb=82
+Time=721  Pitchbend, chan=1 msb=64 lsb=82
 Time=721  Note on, chan=1 pitch=77 vol=80
 Time=960  Note off, chan=1 pitch=77 vol=0
-Time=961  Pitchbend, chan=1 lsb=63 msb=47
+Time=961  Pitchbend, chan=1 msb=63 lsb=47
 Time=961  Note on, chan=1 pitch=79 vol=95
 Time=1200  Note off, chan=1 pitch=79 vol=0
-Time=1201  Pitchbend, chan=1 lsb=62 msb=11
+Time=1201  Pitchbend, chan=1 msb=62 lsb=11
 Time=1201  Note on, chan=1 pitch=81 vol=80
 Time=1440  Note off, chan=1 pitch=81 vol=0
-Time=1441  Pitchbend, chan=1 lsb=64 msb=0
+Time=1441  Pitchbend, chan=1 msb=64 lsb=0
 Time=1441  Note on, chan=1 pitch=83 vol=80
 Time=1680  Note off, chan=1 pitch=83 vol=0
 Time=1681  Note on, chan=1 pitch=84 vol=80
 Time=1920  Note off, chan=1 pitch=84 vol=0
 Time=1920  Key signature, sharp/flats=7  minor=0
-Time=1921  Pitchbend, chan=1 lsb=62 msb=11
+Time=1921  Pitchbend, chan=1 msb=62 lsb=11
 Time=1921  Note on, chan=1 pitch=73 vol=105
 Time=2160  Note off, chan=1 pitch=73 vol=0
-Time=2161  Pitchbend, chan=1 lsb=63 msb=47
+Time=2161  Pitchbend, chan=1 msb=63 lsb=47
 Time=2161  Note on, chan=1 pitch=75 vol=80
 Time=2400  Note off, chan=1 pitch=75 vol=0
-Time=2401  Pitchbend, chan=1 lsb=64 msb=82
+Time=2401  Pitchbend, chan=1 msb=64 lsb=82
 Time=2401  Note on, chan=1 pitch=77 vol=80
 Time=2640  Note off, chan=1 pitch=77 vol=0
-Time=2641  Pitchbend, chan=1 lsb=61 msb=57
+Time=2641  Pitchbend, chan=1 msb=61 lsb=57
 Time=2641  Note on, chan=1 pitch=78 vol=80
 Time=2880  Note off, chan=1 pitch=78 vol=0
-Time=2881  Pitchbend, chan=1 lsb=62 msb=93
+Time=2881  Pitchbend, chan=1 msb=62 lsb=93
 Time=2881  Note on, chan=1 pitch=80 vol=95
 Time=3120  Note off, chan=1 pitch=80 vol=0
-Time=3121  Pitchbend, chan=1 lsb=67 msb=26
+Time=3121  Pitchbend, chan=1 msb=67 lsb=26
 Time=3121  Note on, chan=1 pitch=82 vol=80
 Time=3360  Note off, chan=1 pitch=82 vol=0
-Time=3361  Pitchbend, chan=1 lsb=64 msb=0
+Time=3361  Pitchbend, chan=1 msb=64 lsb=0
 Time=3361  Note on, chan=1 pitch=84 vol=80
 Time=3600  Note off, chan=1 pitch=84 vol=0
-Time=3601  Pitchbend, chan=1 lsb=62 msb=11
+Time=3601  Pitchbend, chan=1 msb=62 lsb=11
 Time=3601  Note on, chan=1 pitch=85 vol=80
 Time=3840  Note off, chan=1 pitch=85 vol=0
 Time=3840  Key signature, sharp/flats=-7  minor=0
-Time=3841  Pitchbend, chan=1 lsb=64 msb=0
+Time=3841  Pitchbend, chan=1 msb=64 lsb=0
 Time=3841  Note on, chan=1 pitch=71 vol=105
 Time=4080  Note off, chan=1 pitch=71 vol=0
-Time=4081  Pitchbend, chan=1 lsb=62 msb=11
+Time=4081  Pitchbend, chan=1 msb=62 lsb=11
 Time=4081  Note on, chan=1 pitch=73 vol=80
 Time=4320  Note off, chan=1 pitch=73 vol=0
-Time=4321  Pitchbend, chan=1 lsb=63 msb=47
+Time=4321  Pitchbend, chan=1 msb=63 lsb=47
 Time=4321  Note on, chan=1 pitch=75 vol=80
 Time=4560  Note off, chan=1 pitch=75 vol=0
-Time=4561  Pitchbend, chan=1 lsb=61 msb=57
+Time=4561  Pitchbend, chan=1 msb=61 lsb=57
 Time=4561  Note on, chan=1 pitch=76 vol=80
 Time=4800  Note off, chan=1 pitch=76 vol=0
 Time=4801  Note on, chan=1 pitch=78 vol=95
 Time=5040  Note off, chan=1 pitch=78 vol=0
-Time=5041  Pitchbend, chan=1 lsb=62 msb=93
+Time=5041  Pitchbend, chan=1 msb=62 lsb=93
 Time=5041  Note on, chan=1 pitch=80 vol=80
 Time=5280  Note off, chan=1 pitch=80 vol=0
-Time=5281  Pitchbend, chan=1 lsb=67 msb=26
+Time=5281  Pitchbend, chan=1 msb=67 lsb=26
 Time=5281  Note on, chan=1 pitch=82 vol=80
 Time=5520  Note off, chan=1 pitch=82 vol=0
-Time=5521  Pitchbend, chan=1 lsb=64 msb=0
+Time=5521  Pitchbend, chan=1 msb=64 lsb=0
 Time=5521  Note on, chan=1 pitch=83 vol=80
 Time=5760  Note off, chan=1 pitch=83 vol=0
 Time=5760  Time signature=12/8  MIDI-clocks/click=72  32nd-notes/24-MIDI-clocks=8
 Time=5760  Key signature, sharp/flats=0  minor=0
 Time=5761  Note on, chan=1 pitch=72 vol=105
 Time=6000  Note off, chan=1 pitch=72 vol=0
-Time=6001  Pitchbend, chan=1 lsb=62 msb=11
+Time=6001  Pitchbend, chan=1 msb=62 lsb=11
 Time=6001  Note on, chan=1 pitch=73 vol=80
 Time=6240  Note off, chan=1 pitch=73 vol=0
-Time=6241  Pitchbend, chan=1 lsb=62 msb=93
+Time=6241  Pitchbend, chan=1 msb=62 lsb=93
 Time=6241  Note on, chan=1 pitch=74 vol=80
 Time=6480  Note off, chan=1 pitch=74 vol=0
-Time=6481  Pitchbend, chan=1 lsb=63 msb=47
+Time=6481  Pitchbend, chan=1 msb=63 lsb=47
 Time=6481  Note on, chan=1 pitch=75 vol=95
 Time=6720  Note off, chan=1 pitch=75 vol=0
-Time=6721  Pitchbend, chan=1 lsb=61 msb=57
+Time=6721  Pitchbend, chan=1 msb=61 lsb=57
 Time=6721  Note on, chan=1 pitch=76 vol=80
 Time=6960  Note off, chan=1 pitch=76 vol=0
-Time=6961  Pitchbend, chan=1 lsb=64 msb=82
+Time=6961  Pitchbend, chan=1 msb=64 lsb=82
 Time=6961  Note on, chan=1 pitch=77 vol=80
 Time=7200  Note off, chan=1 pitch=77 vol=0
-Time=7201  Pitchbend, chan=1 lsb=61 msb=57
+Time=7201  Pitchbend, chan=1 msb=61 lsb=57
 Time=7201  Note on, chan=1 pitch=78 vol=95
 Time=7440  Note off, chan=1 pitch=78 vol=0
-Time=7441  Pitchbend, chan=1 lsb=63 msb=47
+Time=7441  Pitchbend, chan=1 msb=63 lsb=47
 Time=7441  Note on, chan=1 pitch=79 vol=80
 Time=7680  Note off, chan=1 pitch=79 vol=0
-Time=7681  Pitchbend, chan=1 lsb=62 msb=93
+Time=7681  Pitchbend, chan=1 msb=62 lsb=93
 Time=7681  Note on, chan=1 pitch=80 vol=80
 Time=7920  Note off, chan=1 pitch=80 vol=0
-Time=7921  Pitchbend, chan=1 lsb=62 msb=11
+Time=7921  Pitchbend, chan=1 msb=62 lsb=11
 Time=7921  Note on, chan=1 pitch=81 vol=95
 Time=8160  Note off, chan=1 pitch=81 vol=0
-Time=8161  Pitchbend, chan=1 lsb=67 msb=26
+Time=8161  Pitchbend, chan=1 msb=67 lsb=26
 Time=8161  Note on, chan=1 pitch=82 vol=80
 Time=8400  Note off, chan=1 pitch=82 vol=0
-Time=8401  Pitchbend, chan=1 lsb=64 msb=0
+Time=8401  Pitchbend, chan=1 msb=64 lsb=0
 Time=8401  Note on, chan=1 pitch=83 vol=80
 Time=8640  Note off, chan=1 pitch=83 vol=0
 Time=8640  Time signature=13/8  MIDI-clocks/click=39  32nd-notes/24-MIDI-clocks=8
 Time=8641  Note on, chan=1 pitch=72 vol=105
 Time=8880  Note off, chan=1 pitch=72 vol=0
-Time=8881  Pitchbend, chan=1 lsb=62 msb=11
+Time=8881  Pitchbend, chan=1 msb=62 lsb=11
 Time=8881  Note on, chan=1 pitch=73 vol=80
 Time=9120  Note off, chan=1 pitch=73 vol=0
-Time=9121  Pitchbend, chan=1 lsb=62 msb=93
+Time=9121  Pitchbend, chan=1 msb=62 lsb=93
 Time=9121  Note on, chan=1 pitch=74 vol=80
 Time=9360  Note off, chan=1 pitch=74 vol=0
-Time=9361  Pitchbend, chan=1 lsb=63 msb=47
+Time=9361  Pitchbend, chan=1 msb=63 lsb=47
 Time=9361  Note on, chan=1 pitch=75 vol=80
 Time=9600  Note off, chan=1 pitch=75 vol=0
-Time=9601  Pitchbend, chan=1 lsb=61 msb=57
+Time=9601  Pitchbend, chan=1 msb=61 lsb=57
 Time=9601  Note on, chan=1 pitch=76 vol=80
 Time=9840  Note off, chan=1 pitch=76 vol=0
-Time=9841  Pitchbend, chan=1 lsb=64 msb=82
+Time=9841  Pitchbend, chan=1 msb=64 lsb=82
 Time=9841  Note on, chan=1 pitch=77 vol=80
 Time=10080  Note off, chan=1 pitch=77 vol=0
-Time=10081  Pitchbend, chan=1 lsb=61 msb=57
+Time=10081  Pitchbend, chan=1 msb=61 lsb=57
 Time=10081  Note on, chan=1 pitch=78 vol=80
 Time=10320  Note off, chan=1 pitch=78 vol=0
-Time=10321  Pitchbend, chan=1 lsb=63 msb=47
+Time=10321  Pitchbend, chan=1 msb=63 lsb=47
 Time=10321  Note on, chan=1 pitch=79 vol=80
 Time=10560  Note off, chan=1 pitch=79 vol=0
-Time=10561  Pitchbend, chan=1 lsb=62 msb=93
+Time=10561  Pitchbend, chan=1 msb=62 lsb=93
 Time=10561  Note on, chan=1 pitch=80 vol=80
 Time=10800  Note off, chan=1 pitch=80 vol=0
-Time=10801  Pitchbend, chan=1 lsb=62 msb=11
+Time=10801  Pitchbend, chan=1 msb=62 lsb=11
 Time=10801  Note on, chan=1 pitch=81 vol=80
 Time=11040  Note off, chan=1 pitch=81 vol=0
-Time=11041  Pitchbend, chan=1 lsb=67 msb=26
+Time=11041  Pitchbend, chan=1 msb=67 lsb=26
 Time=11041  Note on, chan=1 pitch=82 vol=80
 Time=11280  Note off, chan=1 pitch=82 vol=0
-Time=11281  Pitchbend, chan=1 lsb=64 msb=0
+Time=11281  Pitchbend, chan=1 msb=64 lsb=0
 Time=11281  Note on, chan=1 pitch=83 vol=80
 Time=11520  Note off, chan=1 pitch=83 vol=0
 Time=11521  Note on, chan=1 pitch=84 vol=80

--- a/tests/golden/abc2midi_detune_2.txt
+++ b/tests/golden/abc2midi_detune_2.txt
@@ -17,31 +17,31 @@ Time=1  Program, chan=3 program=16
 Time=1  Meta Text, type=0x01 (Text Event)  leng=21
      Text = < pythagore (~500 B.C)>
 Time=1  Note on, chan=1 pitch=60 vol=105
-Time=11  Pitchbend, chan=2 lsb=66 msb=72
+Time=11  Pitchbend, chan=2 msb=66 lsb=72
 Time=11  Note on, chan=2 pitch=64 vol=105
-Time=21  Pitchbend, chan=3 lsb=64 msb=82
+Time=21  Pitchbend, chan=3 msb=64 lsb=82
 Time=21  Note on, chan=3 pitch=67 vol=105
 Time=1920  Note off, chan=3 pitch=67 vol=0
 Time=1920  Note off, chan=2 pitch=64 vol=0
 Time=1920  Note off, chan=1 pitch=60 vol=0
 Time=2881  Note on, chan=1 pitch=60 vol=95
-Time=2891  Pitchbend, chan=2 lsb=62 msb=11
+Time=2891  Pitchbend, chan=2 msb=62 lsb=11
 Time=2891  Note on, chan=2 pitch=63 vol=95
 Time=2901  Note on, chan=3 pitch=67 vol=95
 Time=4800  Note off, chan=3 pitch=67 vol=0
 Time=4800  Note off, chan=2 pitch=63 vol=0
 Time=4800  Note off, chan=1 pitch=60 vol=0
-Time=5761  Pitchbend, chan=1 lsb=67 msb=108
+Time=5761  Pitchbend, chan=1 msb=67 lsb=108
 Time=5761  Note on, chan=1 pitch=66 vol=105
-Time=5771  Pitchbend, chan=2 lsb=62 msb=93
+Time=5771  Pitchbend, chan=2 msb=62 lsb=93
 Time=5771  Note on, chan=2 pitch=70 vol=105
-Time=5781  Pitchbend, chan=3 lsb=68 msb=61
+Time=5781  Pitchbend, chan=3 msb=68 lsb=61
 Time=5781  Note on, chan=3 pitch=73 vol=105
 Time=7680  Note off, chan=3 pitch=73 vol=0
 Time=7680  Note off, chan=2 pitch=70 vol=0
 Time=7680  Note off, chan=1 pitch=66 vol=0
 Time=8641  Note on, chan=1 pitch=66 vol=95
-Time=8651  Pitchbend, chan=2 lsb=65 msb=118
+Time=8651  Pitchbend, chan=2 msb=65 lsb=118
 Time=8651  Note on, chan=2 pitch=69 vol=95
 Time=8661  Note on, chan=3 pitch=73 vol=95
 Time=10560  Note off, chan=3 pitch=73 vol=0
@@ -49,33 +49,33 @@ Time=10560  Note off, chan=2 pitch=69 vol=0
 Time=10560  Note off, chan=1 pitch=66 vol=0
 Time=10560  Meta Text, type=0x01 (Text Event)  leng=16
      Text = < just intonation>
-Time=11521  Pitchbend, chan=1 lsb=64 msb=0
+Time=11521  Pitchbend, chan=1 msb=64 lsb=0
 Time=11521  Note on, chan=1 pitch=60 vol=105
-Time=11531  Pitchbend, chan=2 lsb=59 msb=68
+Time=11531  Pitchbend, chan=2 msb=59 lsb=68
 Time=11531  Note on, chan=2 pitch=64 vol=105
-Time=11541  Pitchbend, chan=3 lsb=64 msb=82
+Time=11541  Pitchbend, chan=3 msb=64 lsb=82
 Time=11541  Note on, chan=3 pitch=67 vol=105
 Time=13440  Note off, chan=3 pitch=67 vol=0
 Time=13440  Note off, chan=2 pitch=64 vol=0
 Time=13440  Note off, chan=1 pitch=60 vol=0
 Time=14401  Note on, chan=1 pitch=60 vol=95
-Time=14411  Pitchbend, chan=2 lsb=62 msb=11
+Time=14411  Pitchbend, chan=2 msb=62 lsb=11
 Time=14411  Note on, chan=2 pitch=63 vol=95
 Time=14421  Note on, chan=3 pitch=67 vol=95
 Time=16320  Note off, chan=3 pitch=67 vol=0
 Time=16320  Note off, chan=2 pitch=63 vol=0
 Time=16320  Note off, chan=1 pitch=60 vol=0
-Time=17281  Pitchbend, chan=1 lsb=60 msb=103
+Time=17281  Pitchbend, chan=1 msb=60 lsb=103
 Time=17281  Note on, chan=1 pitch=66 vol=105
-Time=17291  Pitchbend, chan=2 lsb=62 msb=93
+Time=17291  Pitchbend, chan=2 msb=62 lsb=93
 Time=17291  Note on, chan=2 pitch=70 vol=105
-Time=17301  Pitchbend, chan=3 lsb=61 msb=57
+Time=17301  Pitchbend, chan=3 msb=61 lsb=57
 Time=17301  Note on, chan=3 pitch=73 vol=105
 Time=19200  Note off, chan=3 pitch=73 vol=0
 Time=19200  Note off, chan=2 pitch=70 vol=0
 Time=19200  Note off, chan=1 pitch=66 vol=0
 Time=20161  Note on, chan=1 pitch=66 vol=95
-Time=20171  Pitchbend, chan=2 lsb=58 msb=114
+Time=20171  Pitchbend, chan=2 msb=58 lsb=114
 Time=20171  Note on, chan=2 pitch=69 vol=95
 Time=20181  Note on, chan=3 pitch=73 vol=95
 Time=22080  Note off, chan=3 pitch=73 vol=0
@@ -83,33 +83,33 @@ Time=22080  Note off, chan=2 pitch=69 vol=0
 Time=22080  Note off, chan=1 pitch=66 vol=0
 Time=22080  Meta Text, type=0x01 (Text Event)  leng=29
      Text = < meantone (Pietro Aaron 1523)>
-Time=23041  Pitchbend, chan=1 lsb=64 msb=0
+Time=23041  Pitchbend, chan=1 msb=64 lsb=0
 Time=23041  Note on, chan=1 pitch=60 vol=105
-Time=23051  Pitchbend, chan=2 lsb=59 msb=68
+Time=23051  Pitchbend, chan=2 msb=59 lsb=68
 Time=23051  Note on, chan=2 pitch=64 vol=105
-Time=23061  Pitchbend, chan=3 lsb=63 msb=6
+Time=23061  Pitchbend, chan=3 msb=63 lsb=6
 Time=23061  Note on, chan=3 pitch=67 vol=105
 Time=24960  Note off, chan=3 pitch=67 vol=0
 Time=24960  Note off, chan=2 pitch=64 vol=0
 Time=24960  Note off, chan=1 pitch=60 vol=0
 Time=25921  Note on, chan=1 pitch=60 vol=95
-Time=25931  Pitchbend, chan=2 lsb=67 msb=26
+Time=25931  Pitchbend, chan=2 msb=67 lsb=26
 Time=25931  Note on, chan=2 pitch=63 vol=95
 Time=25941  Note on, chan=3 pitch=67 vol=95
 Time=27840  Note off, chan=3 pitch=67 vol=0
 Time=27840  Note off, chan=2 pitch=63 vol=0
 Time=27840  Note off, chan=1 pitch=60 vol=0
-Time=28801  Pitchbend, chan=1 lsb=57 msb=37
+Time=28801  Pitchbend, chan=1 msb=57 lsb=37
 Time=28801  Note on, chan=1 pitch=66 vol=105
-Time=28811  Pitchbend, chan=2 lsb=66 msb=31
+Time=28811  Pitchbend, chan=2 msb=66 lsb=31
 Time=28811  Note on, chan=2 pitch=70 vol=105
-Time=28821  Pitchbend, chan=3 lsb=56 msb=42
+Time=28821  Pitchbend, chan=3 msb=56 lsb=42
 Time=28821  Note on, chan=3 pitch=73 vol=105
 Time=30720  Note off, chan=3 pitch=73 vol=0
 Time=30720  Note off, chan=2 pitch=70 vol=0
 Time=30720  Note off, chan=1 pitch=66 vol=0
 Time=31681  Note on, chan=1 pitch=66 vol=95
-Time=31691  Pitchbend, chan=2 lsb=67 msb=26
+Time=31691  Pitchbend, chan=2 msb=67 lsb=26
 Time=31691  Note on, chan=2 pitch=69 vol=95
 Time=31701  Note on, chan=3 pitch=73 vol=95
 Time=33600  Note off, chan=3 pitch=73 vol=0
@@ -117,32 +117,32 @@ Time=33600  Note off, chan=2 pitch=69 vol=0
 Time=33600  Note off, chan=1 pitch=66 vol=0
 Time=33600  Meta Text, type=0x01 (Text Event)  leng=32
      Text = < Andreas Werckmeister III (1681)>
-Time=34561  Pitchbend, chan=1 lsb=64 msb=0
+Time=34561  Pitchbend, chan=1 msb=64 lsb=0
 Time=34561  Note on, chan=1 pitch=60 vol=105
-Time=34571  Pitchbend, chan=2 lsb=62 msb=93
+Time=34571  Pitchbend, chan=2 msb=62 lsb=93
 Time=34571  Note on, chan=2 pitch=64 vol=105
-Time=34581  Pitchbend, chan=3 lsb=64 msb=82
+Time=34581  Pitchbend, chan=3 msb=64 lsb=82
 Time=34581  Note on, chan=3 pitch=67 vol=105
 Time=36480  Note off, chan=3 pitch=67 vol=0
 Time=36480  Note off, chan=2 pitch=64 vol=0
 Time=36480  Note off, chan=1 pitch=60 vol=0
 Time=37441  Note on, chan=1 pitch=60 vol=95
-Time=37451  Pitchbend, chan=2 lsb=64 msb=0
+Time=37451  Pitchbend, chan=2 msb=64 lsb=0
 Time=37451  Note on, chan=2 pitch=63 vol=95
 Time=37461  Note on, chan=3 pitch=67 vol=95
 Time=39360  Note off, chan=3 pitch=67 vol=0
 Time=39360  Note off, chan=2 pitch=63 vol=0
 Time=39360  Note off, chan=1 pitch=60 vol=0
 Time=40321  Note on, chan=1 pitch=66 vol=105
-Time=40331  Pitchbend, chan=2 lsb=64 msb=82
+Time=40331  Pitchbend, chan=2 msb=64 lsb=82
 Time=40331  Note on, chan=2 pitch=70 vol=105
-Time=40341  Pitchbend, chan=3 lsb=62 msb=93
+Time=40341  Pitchbend, chan=3 msb=62 lsb=93
 Time=40341  Note on, chan=3 pitch=73 vol=105
 Time=42240  Note off, chan=3 pitch=73 vol=0
 Time=42240  Note off, chan=2 pitch=70 vol=0
 Time=42240  Note off, chan=1 pitch=66 vol=0
 Time=43201  Note on, chan=1 pitch=66 vol=95
-Time=43211  Pitchbend, chan=2 lsb=64 msb=0
+Time=43211  Pitchbend, chan=2 msb=64 lsb=0
 Time=43211  Note on, chan=2 pitch=69 vol=95
 Time=43221  Note on, chan=3 pitch=73 vol=95
 Time=45120  Note off, chan=3 pitch=73 vol=0
@@ -151,31 +151,31 @@ Time=45120  Note off, chan=1 pitch=66 vol=0
 Time=45120  Meta Text, type=0x01 (Text Event)  leng=38
      Text = < well temperament (F.A. Vallotti 1754)>
 Time=46081  Note on, chan=1 pitch=60 vol=105
-Time=46091  Pitchbend, chan=2 lsb=61 msb=57
+Time=46091  Pitchbend, chan=2 msb=61 lsb=57
 Time=46091  Note on, chan=2 pitch=64 vol=105
-Time=46101  Pitchbend, chan=3 lsb=63 msb=47
+Time=46101  Pitchbend, chan=3 msb=63 lsb=47
 Time=46101  Note on, chan=3 pitch=67 vol=105
 Time=48000  Note off, chan=3 pitch=67 vol=0
 Time=48000  Note off, chan=2 pitch=64 vol=0
 Time=48000  Note off, chan=1 pitch=60 vol=0
 Time=48961  Note on, chan=1 pitch=60 vol=95
-Time=48971  Pitchbend, chan=2 lsb=63 msb=47
+Time=48971  Pitchbend, chan=2 msb=63 lsb=47
 Time=48971  Note on, chan=2 pitch=63 vol=95
 Time=48981  Note on, chan=3 pitch=67 vol=95
 Time=50880  Note off, chan=3 pitch=67 vol=0
 Time=50880  Note off, chan=2 pitch=63 vol=0
 Time=50880  Note off, chan=1 pitch=60 vol=0
-Time=51841  Pitchbend, chan=1 lsb=61 msb=57
+Time=51841  Pitchbend, chan=1 msb=61 lsb=57
 Time=51841  Note on, chan=1 pitch=66 vol=105
-Time=51851  Pitchbend, chan=2 lsb=64 msb=0
+Time=51851  Pitchbend, chan=2 msb=64 lsb=0
 Time=51851  Note on, chan=2 pitch=70 vol=105
-Time=51861  Pitchbend, chan=3 lsb=62 msb=11
+Time=51861  Pitchbend, chan=3 msb=62 lsb=11
 Time=51861  Note on, chan=3 pitch=73 vol=105
 Time=53760  Note off, chan=3 pitch=73 vol=0
 Time=53760  Note off, chan=2 pitch=70 vol=0
 Time=53760  Note off, chan=1 pitch=66 vol=0
 Time=54721  Note on, chan=1 pitch=66 vol=95
-Time=54731  Pitchbend, chan=2 lsb=62 msb=11
+Time=54731  Pitchbend, chan=2 msb=62 lsb=11
 Time=54731  Note on, chan=2 pitch=69 vol=95
 Time=54741  Note on, chan=3 pitch=73 vol=95
 Time=56640  Note off, chan=3 pitch=73 vol=0
@@ -183,11 +183,11 @@ Time=56640  Note off, chan=2 pitch=69 vol=0
 Time=56640  Note off, chan=1 pitch=66 vol=0
 Time=56640  Meta Text, type=0x01 (Text Event)  leng=26
      Text = < 12-tone equal temperament>
-Time=57601  Pitchbend, chan=1 lsb=64 msb=0
+Time=57601  Pitchbend, chan=1 msb=64 lsb=0
 Time=57601  Note on, chan=1 pitch=60 vol=105
-Time=57611  Pitchbend, chan=2 lsb=64 msb=0
+Time=57611  Pitchbend, chan=2 msb=64 lsb=0
 Time=57611  Note on, chan=2 pitch=64 vol=105
-Time=57621  Pitchbend, chan=3 lsb=64 msb=0
+Time=57621  Pitchbend, chan=3 msb=64 lsb=0
 Time=57621  Note on, chan=3 pitch=67 vol=105
 Time=59520  Note off, chan=3 pitch=67 vol=0
 Time=59520  Note off, chan=2 pitch=64 vol=0

--- a/tests/golden/abc2midi_temperament.txt
+++ b/tests/golden/abc2midi_temperament.txt
@@ -22,37 +22,37 @@ Time=1  Program, chan=1 program=17
 Time=1  Program, chan=2 program=17
 Time=1  Program, chan=3 program=17
 Time=1  Program, chan=4 program=17
-Time=1  Pitchbend, chan=1 lsb=62 msb=10
+Time=1  Pitchbend, chan=1 msb=62 lsb=10
 Time=1  Note on, chan=1 pitch=60 vol=105
-Time=11  Pitchbend, chan=2 lsb=56 msb=79
+Time=11  Pitchbend, chan=2 msb=56 lsb=79
 Time=11  Note on, chan=2 pitch=64 vol=105
-Time=21  Pitchbend, chan=3 lsb=62 msb=92
+Time=21  Pitchbend, chan=3 msb=62 lsb=92
 Time=21  Note on, chan=3 pitch=67 vol=105
 Time=1920  Note off, chan=3 pitch=67 vol=0
 Time=1920  Note off, chan=2 pitch=64 vol=0
 Time=1920  Note off, chan=1 pitch=60 vol=0
 Time=1921  Note on, chan=1 pitch=60 vol=105
-Time=1931  Pitchbend, chan=2 lsb=64 msb=82
+Time=1931  Pitchbend, chan=2 msb=64 lsb=82
 Time=1931  Note on, chan=2 pitch=64 vol=105
 Time=1941  Note on, chan=3 pitch=67 vol=105
 Time=3840  Note off, chan=3 pitch=67 vol=0
 Time=3840  Note off, chan=2 pitch=64 vol=0
 Time=3840  Note off, chan=1 pitch=60 vol=0
 Time=3841  Note on, chan=1 pitch=60 vol=95
-Time=3851  Pitchbend, chan=2 lsb=56 msb=79
+Time=3851  Pitchbend, chan=2 msb=56 lsb=79
 Time=3851  Note on, chan=2 pitch=64 vol=95
 Time=3861  Note on, chan=3 pitch=67 vol=95
-Time=3871  Pitchbend, chan=4 lsb=77 msb=108
+Time=3871  Pitchbend, chan=4 msb=77 lsb=108
 Time=3871  Note on, chan=4 pitch=69 vol=95
 Time=5760  Note off, chan=4 pitch=69 vol=0
 Time=5760  Note off, chan=3 pitch=67 vol=0
 Time=5760  Note off, chan=2 pitch=64 vol=0
 Time=5760  Note off, chan=1 pitch=60 vol=0
 Time=5761  Note on, chan=1 pitch=60 vol=105
-Time=5771  Pitchbend, chan=2 lsb=64 msb=82
+Time=5771  Pitchbend, chan=2 msb=64 lsb=82
 Time=5771  Note on, chan=2 pitch=64 vol=105
 Time=5781  Note on, chan=3 pitch=67 vol=105
-Time=5791  Pitchbend, chan=4 lsb=60 msb=102
+Time=5791  Pitchbend, chan=4 msb=60 lsb=102
 Time=5791  Note on, chan=4 pitch=70 vol=105
 Time=7680  Note off, chan=4 pitch=70 vol=0
 Time=7680  Note off, chan=3 pitch=67 vol=0

--- a/tests/golden/abc2midi_temperament_2.txt
+++ b/tests/golden/abc2midi_temperament_2.txt
@@ -24,36 +24,36 @@ Time=1  Program, chan=3 program=44
 Time=1  Program, chan=4 program=44
 Time=1  Meta Text, type=0x01 (Text Event)  leng=0
      Text = <>
-Time=1  Pitchbend, chan=1 lsb=77 msb=91
+Time=1  Pitchbend, chan=1 msb=77 lsb=91
 Time=1  Note on, chan=1 pitch=72 vol=105
 Time=960  Note off, chan=1 pitch=72 vol=0
-Time=961  Pitchbend, chan=1 lsb=68 msb=73
+Time=961  Pitchbend, chan=1 msb=68 lsb=73
 Time=961  Note on, chan=1 pitch=74 vol=95
 Time=1920  Note off, chan=1 pitch=74 vol=0
-Time=1921  Pitchbend, chan=1 lsb=59 msb=55
+Time=1921  Pitchbend, chan=1 msb=59 lsb=55
 Time=1921  Note on, chan=1 pitch=76 vol=95
 Time=2880  Note off, chan=1 pitch=76 vol=0
-Time=2881  Pitchbend, chan=1 lsb=50 msb=37
+Time=2881  Pitchbend, chan=1 msb=50 lsb=37
 Time=2881  Note on, chan=1 pitch=78 vol=95
 Time=3840  Note off, chan=1 pitch=78 vol=0
-Time=3841  Pitchbend, chan=1 lsb=73 msb=18
+Time=3841  Pitchbend, chan=1 msb=73 lsb=18
 Time=3841  Note on, chan=1 pitch=79 vol=95
 Time=4800  Note off, chan=1 pitch=79 vol=0
-Time=4801  Pitchbend, chan=1 lsb=64 msb=0
+Time=4801  Pitchbend, chan=1 msb=64 lsb=0
 Time=4801  Note on, chan=1 pitch=81 vol=95
 Time=5760  Note off, chan=1 pitch=81 vol=0
-Time=5761  Pitchbend, chan=1 lsb=54 msb=110
+Time=5761  Pitchbend, chan=1 msb=54 lsb=110
 Time=5761  Note on, chan=1 pitch=83 vol=95
 Time=6720  Note off, chan=1 pitch=83 vol=0
-Time=6721  Pitchbend, chan=1 lsb=77 msb=91
+Time=6721  Pitchbend, chan=1 msb=77 lsb=91
 Time=6721  Note on, chan=1 pitch=84 vol=95
 Time=7680  Note off, chan=1 pitch=84 vol=0
 Time=7681  Note on, chan=1 pitch=60 vol=105
-Time=7691  Pitchbend, chan=2 lsb=59 msb=55
+Time=7691  Pitchbend, chan=2 msb=59 lsb=55
 Time=7691  Note on, chan=2 pitch=64 vol=105
-Time=7701  Pitchbend, chan=3 lsb=73 msb=18
+Time=7701  Pitchbend, chan=3 msb=73 lsb=18
 Time=7701  Note on, chan=3 pitch=67 vol=105
-Time=7711  Pitchbend, chan=4 lsb=77 msb=91
+Time=7711  Pitchbend, chan=4 msb=77 lsb=91
 Time=7711  Note on, chan=4 pitch=72 vol=105
 Time=9600  Note off, chan=4 pitch=72 vol=0
 Time=9600  Note off, chan=3 pitch=67 vol=0
@@ -61,33 +61,33 @@ Time=9600  Note off, chan=2 pitch=64 vol=0
 Time=9600  Note off, chan=1 pitch=60 vol=0
 Time=9600  Meta Text, type=0x01 (Text Event)  leng=0
      Text = <>
-Time=10561  Pitchbend, chan=1 lsb=58 msb=45
+Time=10561  Pitchbend, chan=1 msb=58 lsb=45
 Time=10561  Note on, chan=1 pitch=72 vol=105
 Time=11520  Note off, chan=1 pitch=72 vol=0
-Time=11521  Pitchbend, chan=1 lsb=48 msb=120
+Time=11521  Pitchbend, chan=1 msb=48 lsb=120
 Time=11521  Note on, chan=1 pitch=73 vol=95
 Time=12480  Note off, chan=1 pitch=73 vol=0
-Time=12481  Pitchbend, chan=1 lsb=71 msb=68
+Time=12481  Pitchbend, chan=1 msb=71 lsb=68
 Time=12481  Note on, chan=1 pitch=73 vol=95
 Time=13440  Note off, chan=1 pitch=73 vol=0
-Time=13441  Pitchbend, chan=1 lsb=62 msb=15
+Time=13441  Pitchbend, chan=1 msb=62 lsb=15
 Time=13441  Note on, chan=1 pitch=74 vol=95
 Time=14400  Note off, chan=1 pitch=74 vol=0
-Time=14401  Pitchbend, chan=1 lsb=71 msb=68
+Time=14401  Pitchbend, chan=1 msb=71 lsb=68
 Time=14401  Note on, chan=1 pitch=73 vol=95
 Time=15360  Note off, chan=1 pitch=73 vol=0
-Time=15361  Pitchbend, chan=1 lsb=48 msb=121
+Time=15361  Pitchbend, chan=1 msb=48 lsb=121
 Time=15361  Note on, chan=1 pitch=73 vol=95
 Time=16320  Note off, chan=1 pitch=73 vol=0
-Time=16321  Pitchbend, chan=1 lsb=58 msb=45
+Time=16321  Pitchbend, chan=1 msb=58 lsb=45
 Time=16321  Note on, chan=1 pitch=72 vol=95
 Time=17280  Note off, chan=1 pitch=72 vol=0
 Time=17281  Note on, chan=1 pitch=60 vol=105
-Time=17291  Pitchbend, chan=2 lsb=65 msb=113
+Time=17291  Pitchbend, chan=2 msb=65 lsb=113
 Time=17291  Note on, chan=2 pitch=64 vol=105
-Time=17301  Pitchbend, chan=3 lsb=60 msb=30
+Time=17301  Pitchbend, chan=3 msb=60 lsb=30
 Time=17301  Note on, chan=3 pitch=67 vol=105
-Time=17311  Pitchbend, chan=4 lsb=58 msb=45
+Time=17311  Pitchbend, chan=4 msb=58 lsb=45
 Time=17311  Note on, chan=4 pitch=72 vol=105
 Time=19200  Note off, chan=4 pitch=72 vol=0
 Time=19200  Note off, chan=3 pitch=67 vol=0
@@ -95,39 +95,39 @@ Time=19200  Note off, chan=2 pitch=64 vol=0
 Time=19200  Note off, chan=1 pitch=60 vol=0
 Time=19200  Meta Text, type=0x01 (Text Event)  leng=0
      Text = <>
-Time=20161  Pitchbend, chan=1 lsb=55 msb=35
+Time=20161  Pitchbend, chan=1 msb=55 lsb=35
 Time=20161  Note on, chan=1 pitch=72 vol=105
 Time=21120  Note off, chan=1 pitch=72 vol=0
-Time=21121  Pitchbend, chan=1 lsb=72 msb=93
+Time=21121  Pitchbend, chan=1 msb=72 lsb=93
 Time=21121  Note on, chan=1 pitch=72 vol=95
 Time=22080  Note off, chan=1 pitch=72 vol=0
-Time=22081  Pitchbend, chan=1 lsb=58 msb=23
+Time=22081  Pitchbend, chan=1 msb=58 lsb=23
 Time=22081  Note on, chan=1 pitch=73 vol=95
 Time=23040  Note off, chan=1 pitch=73 vol=0
-Time=23041  Pitchbend, chan=1 lsb=75 msb=81
+Time=23041  Pitchbend, chan=1 msb=75 lsb=81
 Time=23041  Note on, chan=1 pitch=73 vol=95
 Time=24000  Note off, chan=1 pitch=73 vol=0
-Time=24001  Pitchbend, chan=1 lsb=61 msb=12
+Time=24001  Pitchbend, chan=1 msb=61 lsb=12
 Time=24001  Note on, chan=1 pitch=74 vol=95
 Time=24960  Note off, chan=1 pitch=74 vol=0
-Time=24961  Pitchbend, chan=1 lsb=75 msb=81
+Time=24961  Pitchbend, chan=1 msb=75 lsb=81
 Time=24961  Note on, chan=1 pitch=73 vol=95
 Time=25920  Note off, chan=1 pitch=73 vol=0
-Time=25921  Pitchbend, chan=1 lsb=58 msb=23
+Time=25921  Pitchbend, chan=1 msb=58 lsb=23
 Time=25921  Note on, chan=1 pitch=73 vol=95
 Time=26880  Note off, chan=1 pitch=73 vol=0
-Time=26881  Pitchbend, chan=1 lsb=72 msb=93
+Time=26881  Pitchbend, chan=1 msb=72 lsb=93
 Time=26881  Note on, chan=1 pitch=72 vol=95
 Time=27840  Note off, chan=1 pitch=72 vol=0
-Time=27841  Pitchbend, chan=1 lsb=55 msb=35
+Time=27841  Pitchbend, chan=1 msb=55 lsb=35
 Time=27841  Note on, chan=1 pitch=72 vol=95
 Time=28800  Note off, chan=1 pitch=72 vol=0
 Time=28801  Note on, chan=1 pitch=60 vol=105
-Time=28811  Pitchbend, chan=2 lsb=49 msb=58
+Time=28811  Pitchbend, chan=2 msb=49 lsb=58
 Time=28811  Note on, chan=2 pitch=64 vol=105
-Time=28821  Pitchbend, chan=3 lsb=58 msb=23
+Time=28821  Pitchbend, chan=3 msb=58 lsb=23
 Time=28821  Note on, chan=3 pitch=67 vol=105
-Time=28831  Pitchbend, chan=4 lsb=55 msb=35
+Time=28831  Pitchbend, chan=4 msb=55 lsb=35
 Time=28831  Note on, chan=4 pitch=72 vol=105
 Time=30720  Note off, chan=4 pitch=72 vol=0
 Time=30720  Note off, chan=3 pitch=67 vol=0
@@ -135,45 +135,45 @@ Time=30720  Note off, chan=2 pitch=64 vol=0
 Time=30720  Note off, chan=1 pitch=60 vol=0
 Time=30720  Meta Text, type=0x01 (Text Event)  leng=0
      Text = <>
-Time=31681  Pitchbend, chan=1 lsb=67 msb=12
+Time=31681  Pitchbend, chan=1 msb=67 lsb=12
 Time=31681  Note on, chan=1 pitch=72 vol=105
 Time=32640  Note off, chan=1 pitch=72 vol=0
-Time=32641  Pitchbend, chan=1 lsb=79 msb=62
+Time=32641  Pitchbend, chan=1 msb=79 lsb=62
 Time=32641  Note on, chan=1 pitch=72 vol=95
 Time=33600  Note off, chan=1 pitch=72 vol=0
-Time=33601  Pitchbend, chan=1 lsb=59 msb=111
+Time=33601  Pitchbend, chan=1 msb=59 lsb=111
 Time=33601  Note on, chan=1 pitch=73 vol=95
 Time=34560  Note off, chan=1 pitch=73 vol=0
-Time=34561  Pitchbend, chan=1 lsb=72 msb=33
+Time=34561  Pitchbend, chan=1 msb=72 lsb=33
 Time=34561  Note on, chan=1 pitch=73 vol=95
 Time=35520  Note off, chan=1 pitch=73 vol=0
-Time=35521  Pitchbend, chan=1 lsb=52 msb=83
+Time=35521  Pitchbend, chan=1 msb=52 lsb=83
 Time=35521  Note on, chan=1 pitch=74 vol=95
 Time=36480  Note off, chan=1 pitch=74 vol=0
-Time=36481  Pitchbend, chan=1 lsb=65 msb=4
+Time=36481  Pitchbend, chan=1 msb=65 lsb=4
 Time=36481  Note on, chan=1 pitch=74 vol=95
 Time=37440  Note off, chan=1 pitch=74 vol=0
-Time=37441  Pitchbend, chan=1 lsb=52 msb=83
+Time=37441  Pitchbend, chan=1 msb=52 lsb=83
 Time=37441  Note on, chan=1 pitch=74 vol=95
 Time=38400  Note off, chan=1 pitch=74 vol=0
-Time=38401  Pitchbend, chan=1 lsb=72 msb=33
+Time=38401  Pitchbend, chan=1 msb=72 lsb=33
 Time=38401  Note on, chan=1 pitch=73 vol=95
 Time=39360  Note off, chan=1 pitch=73 vol=0
-Time=39361  Pitchbend, chan=1 lsb=59 msb=112
+Time=39361  Pitchbend, chan=1 msb=59 lsb=112
 Time=39361  Note on, chan=1 pitch=73 vol=95
 Time=40320  Note off, chan=1 pitch=73 vol=0
-Time=40321  Pitchbend, chan=1 lsb=79 msb=62
+Time=40321  Pitchbend, chan=1 msb=79 lsb=62
 Time=40321  Note on, chan=1 pitch=72 vol=95
 Time=41280  Note off, chan=1 pitch=72 vol=0
-Time=41281  Pitchbend, chan=1 lsb=67 msb=12
+Time=41281  Pitchbend, chan=1 msb=67 lsb=12
 Time=41281  Note on, chan=1 pitch=72 vol=95
 Time=43200  Note off, chan=1 pitch=72 vol=0
 Time=43201  Note on, chan=1 pitch=60 vol=105
-Time=43211  Pitchbend, chan=2 lsb=62 msb=124
+Time=43211  Pitchbend, chan=2 msb=62 lsb=124
 Time=43211  Note on, chan=2 pitch=64 vol=105
-Time=43221  Pitchbend, chan=3 lsb=66 msb=8
+Time=43221  Pitchbend, chan=3 msb=66 lsb=8
 Time=43221  Note on, chan=3 pitch=67 vol=105
-Time=43231  Pitchbend, chan=4 lsb=67 msb=12
+Time=43231  Pitchbend, chan=4 msb=67 lsb=12
 Time=43231  Note on, chan=4 pitch=72 vol=105
 Time=45120  Note off, chan=4 pitch=72 vol=0
 Time=45120  Note off, chan=3 pitch=67 vol=0
@@ -181,33 +181,33 @@ Time=45120  Note off, chan=2 pitch=64 vol=0
 Time=45120  Note off, chan=1 pitch=60 vol=0
 Time=45120  Meta Text, type=0x01 (Text Event)  leng=0
      Text = <>
-Time=46081  Pitchbend, chan=1 lsb=69 msb=7
+Time=46081  Pitchbend, chan=1 msb=69 lsb=7
 Time=46081  Note on, chan=1 pitch=72 vol=105
 Time=47040  Note off, chan=1 pitch=72 vol=0
-Time=47041  Pitchbend, chan=1 lsb=57 msb=34
+Time=47041  Pitchbend, chan=1 msb=57 lsb=34
 Time=47041  Note on, chan=1 pitch=73 vol=95
 Time=48000  Note off, chan=1 pitch=73 vol=0
-Time=48001  Pitchbend, chan=1 lsb=77 msb=61
+Time=48001  Pitchbend, chan=1 msb=77 lsb=61
 Time=48001  Note on, chan=1 pitch=73 vol=95
 Time=48960  Note off, chan=1 pitch=73 vol=0
-Time=48961  Pitchbend, chan=1 lsb=65 msb=88
+Time=48961  Pitchbend, chan=1 msb=65 lsb=88
 Time=48961  Note on, chan=1 pitch=74 vol=95
 Time=49920  Note off, chan=1 pitch=74 vol=0
-Time=49921  Pitchbend, chan=1 lsb=77 msb=61
+Time=49921  Pitchbend, chan=1 msb=77 lsb=61
 Time=49921  Note on, chan=1 pitch=73 vol=95
 Time=50880  Note off, chan=1 pitch=73 vol=0
-Time=50881  Pitchbend, chan=1 lsb=57 msb=34
+Time=50881  Pitchbend, chan=1 msb=57 lsb=34
 Time=50881  Note on, chan=1 pitch=73 vol=95
 Time=51840  Note off, chan=1 pitch=73 vol=0
-Time=51841  Pitchbend, chan=1 lsb=69 msb=7
+Time=51841  Pitchbend, chan=1 msb=69 lsb=7
 Time=51841  Note on, chan=1 pitch=72 vol=95
 Time=52800  Note off, chan=1 pitch=72 vol=0
 Time=52801  Note on, chan=1 pitch=60 vol=105
-Time=52811  Pitchbend, chan=2 lsb=62 msb=40
+Time=52811  Pitchbend, chan=2 msb=62 lsb=40
 Time=52811  Note on, chan=2 pitch=64 vol=105
-Time=52821  Pitchbend, chan=3 lsb=67 msb=47
+Time=52821  Pitchbend, chan=3 msb=67 lsb=47
 Time=52821  Note on, chan=3 pitch=67 vol=105
-Time=52831  Pitchbend, chan=4 lsb=69 msb=7
+Time=52831  Pitchbend, chan=4 msb=69 lsb=7
 Time=52831  Note on, chan=4 pitch=72 vol=105
 Time=54720  Note off, chan=4 pitch=72 vol=0
 Time=54720  Note off, chan=3 pitch=67 vol=0
@@ -215,34 +215,34 @@ Time=54720  Note off, chan=2 pitch=64 vol=0
 Time=54720  Note off, chan=1 pitch=60 vol=0
 Time=54720  Meta Text, type=0x01 (Text Event)  leng=0
      Text = <>
-Time=55681  Pitchbend, chan=1 lsb=69 msb=61
+Time=55681  Pitchbend, chan=1 msb=69 lsb=61
 Time=55681  Note on, chan=1 pitch=72 vol=105
 Time=56640  Note off, chan=1 pitch=72 vol=0
-Time=56641  Pitchbend, chan=1 lsb=57 msb=98
+Time=56641  Pitchbend, chan=1 msb=57 lsb=98
 Time=56641  Note on, chan=1 pitch=73 vol=95
 Time=57600  Note off, chan=1 pitch=73 vol=0
-Time=57601  Pitchbend, chan=1 lsb=78 msb=8
+Time=57601  Pitchbend, chan=1 msb=78 lsb=8
 Time=57601  Note on, chan=1 pitch=73 vol=95
 Time=58560  Note off, chan=1 pitch=73 vol=0
-Time=58561  Pitchbend, chan=1 lsb=66 msb=46
+Time=58561  Pitchbend, chan=1 msb=66 lsb=46
 Time=58561  Note on, chan=1 pitch=74 vol=95
 Time=59520  Note off, chan=1 pitch=74 vol=0
-Time=59521  Pitchbend, chan=1 lsb=78 msb=8
+Time=59521  Pitchbend, chan=1 msb=78 lsb=8
 Time=59521  Note on, chan=1 pitch=73 vol=95
 Time=60480  Note off, chan=1 pitch=73 vol=0
-Time=60481  Pitchbend, chan=1 lsb=57 msb=98
+Time=60481  Pitchbend, chan=1 msb=57 lsb=98
 Time=60481  Note on, chan=1 pitch=73 vol=95
 Time=61440  Note off, chan=1 pitch=73 vol=0
-Time=61441  Pitchbend, chan=1 lsb=69 msb=61
+Time=61441  Pitchbend, chan=1 msb=69 lsb=61
 Time=61441  Note on, chan=1 pitch=72 vol=95
 Time=62400  Note off, chan=1 pitch=72 vol=0
-Time=62401  Pitchbend, chan=1 lsb=67 msb=112
+Time=62401  Pitchbend, chan=1 msb=67 lsb=112
 Time=62401  Note on, chan=1 pitch=60 vol=105
-Time=62411  Pitchbend, chan=2 lsb=61 msb=82
+Time=62411  Pitchbend, chan=2 msb=61 lsb=82
 Time=62411  Note on, chan=2 pitch=64 vol=105
-Time=62421  Pitchbend, chan=3 lsb=67 msb=15
+Time=62421  Pitchbend, chan=3 msb=67 lsb=15
 Time=62421  Note on, chan=3 pitch=67 vol=105
-Time=62431  Pitchbend, chan=4 lsb=69 msb=61
+Time=62431  Pitchbend, chan=4 msb=69 lsb=61
 Time=62431  Note on, chan=4 pitch=72 vol=105
 Time=64320  Note off, chan=4 pitch=72 vol=0
 Time=64320  Note off, chan=3 pitch=67 vol=0
@@ -250,45 +250,45 @@ Time=64320  Note off, chan=2 pitch=64 vol=0
 Time=64320  Note off, chan=1 pitch=60 vol=0
 Time=64320  Meta Text, type=0x01 (Text Event)  leng=0
      Text = <>
-Time=65281  Pitchbend, chan=1 lsb=66 msb=116
+Time=65281  Pitchbend, chan=1 msb=66 lsb=116
 Time=65281  Note on, chan=1 pitch=70 vol=105
 Time=66240  Note off, chan=1 pitch=70 vol=0
-Time=66241  Pitchbend, chan=1 lsb=69 msb=105
+Time=66241  Pitchbend, chan=1 msb=69 lsb=105
 Time=66241  Note on, chan=1 pitch=71 vol=95
 Time=67200  Note off, chan=1 pitch=71 vol=0
-Time=67201  Pitchbend, chan=1 lsb=72 msb=93
+Time=67201  Pitchbend, chan=1 msb=72 lsb=93
 Time=67201  Note on, chan=1 pitch=72 vol=95
 Time=68160  Note off, chan=1 pitch=72 vol=0
-Time=68161  Pitchbend, chan=1 lsb=75 msb=81
+Time=68161  Pitchbend, chan=1 msb=75 lsb=81
 Time=68161  Note on, chan=1 pitch=73 vol=95
 Time=69120  Note off, chan=1 pitch=73 vol=0
-Time=69121  Pitchbend, chan=1 lsb=78 msb=70
+Time=69121  Pitchbend, chan=1 msb=78 lsb=70
 Time=69121  Note on, chan=1 pitch=74 vol=95
 Time=70080  Note off, chan=1 pitch=74 vol=0
-Time=70081  Pitchbend, chan=1 lsb=49 msb=58
+Time=70081  Pitchbend, chan=1 msb=49 lsb=58
 Time=70081  Note on, chan=1 pitch=76 vol=95
 Time=71040  Note off, chan=1 pitch=76 vol=0
-Time=71041  Pitchbend, chan=1 lsb=52 msb=47
+Time=71041  Pitchbend, chan=1 msb=52 lsb=47
 Time=71041  Note on, chan=1 pitch=77 vol=95
 Time=72000  Note off, chan=1 pitch=77 vol=0
-Time=72001  Pitchbend, chan=1 lsb=55 msb=35
+Time=72001  Pitchbend, chan=1 msb=55 lsb=35
 Time=72001  Note on, chan=1 pitch=78 vol=95
 Time=72960  Note off, chan=1 pitch=78 vol=0
-Time=72961  Pitchbend, chan=1 lsb=58 msb=23
+Time=72961  Pitchbend, chan=1 msb=58 lsb=23
 Time=72961  Note on, chan=1 pitch=79 vol=95
 Time=73920  Note off, chan=1 pitch=79 vol=0
-Time=73921  Pitchbend, chan=1 lsb=61 msb=12
+Time=73921  Pitchbend, chan=1 msb=61 lsb=12
 Time=73921  Note on, chan=1 pitch=80 vol=95
 Time=74880  Note off, chan=1 pitch=80 vol=0
-Time=74881  Pitchbend, chan=1 lsb=64 msb=0
+Time=74881  Pitchbend, chan=1 msb=64 lsb=0
 Time=74881  Note on, chan=1 pitch=81 vol=95
 Time=75840  Note off, chan=1 pitch=81 vol=0
-Time=75841  Pitchbend, chan=1 lsb=66 msb=116
+Time=75841  Pitchbend, chan=1 msb=66 lsb=116
 Time=75841  Note on, chan=1 pitch=82 vol=95
 Time=76800  Note off, chan=1 pitch=82 vol=0
 Time=76800  Meta Text, type=0x01 (Text Event)  leng=0
      Text = <>
-Time=76801  Pitchbend, chan=1 lsb=64 msb=0
+Time=76801  Pitchbend, chan=1 msb=64 lsb=0
 Time=76801  Note on, chan=1 pitch=72 vol=105
 Time=77760  Note off, chan=1 pitch=72 vol=0
 Time=77761  Note on, chan=1 pitch=73 vol=95
@@ -320,28 +320,28 @@ Track end
 Track start
 Time=0  Meta Text, type=0x01 (Text Event)  leng=10
      Text = <note track>
-Time=1  Pitchbend, chan=5 lsb=77 msb=91
+Time=1  Pitchbend, chan=5 msb=77 lsb=91
 Time=1  Note on, chan=5 pitch=60 vol=105
 Time=7680  Note off, chan=5 pitch=60 vol=0
-Time=10561  Pitchbend, chan=5 lsb=58 msb=45
+Time=10561  Pitchbend, chan=5 msb=58 lsb=45
 Time=10561  Note on, chan=5 pitch=60 vol=105
 Time=17280  Note off, chan=5 pitch=60 vol=0
-Time=20161  Pitchbend, chan=5 lsb=55 msb=35
+Time=20161  Pitchbend, chan=5 msb=55 lsb=35
 Time=20161  Note on, chan=5 pitch=60 vol=105
 Time=28800  Note off, chan=5 pitch=60 vol=0
-Time=31681  Pitchbend, chan=5 lsb=67 msb=12
+Time=31681  Pitchbend, chan=5 msb=67 lsb=12
 Time=31681  Note on, chan=5 pitch=60 vol=105
 Time=43200  Note off, chan=5 pitch=60 vol=0
-Time=46081  Pitchbend, chan=5 lsb=69 msb=7
+Time=46081  Pitchbend, chan=5 msb=69 lsb=7
 Time=46081  Note on, chan=5 pitch=60 vol=105
 Time=52800  Note off, chan=5 pitch=60 vol=0
-Time=55681  Pitchbend, chan=5 lsb=67 msb=112
+Time=55681  Pitchbend, chan=5 msb=67 lsb=112
 Time=55681  Note on, chan=5 pitch=60 vol=105
 Time=62400  Note off, chan=5 pitch=60 vol=0
-Time=65281  Pitchbend, chan=5 lsb=66 msb=116
+Time=65281  Pitchbend, chan=5 msb=66 lsb=116
 Time=65281  Note on, chan=5 pitch=58 vol=105
 Time=76800  Note off, chan=5 pitch=58 vol=0
-Time=76801  Pitchbend, chan=5 lsb=64 msb=0
+Time=76801  Pitchbend, chan=5 msb=64 lsb=0
 Time=76801  Note on, chan=5 pitch=60 vol=105
 Time=90240  Note off, chan=5 pitch=60 vol=0
 Time=90266  Meta event, end of track


### PR DESCRIPTION
## Summary

Fixes the `mftext` Pitchbend text dump, which printed its two data bytes under **swapped `lsb=`/`msb=` labels** — reported in #6.

MIDI pitch-bend events are `En lsb msb`; `midifile.c` passes the first data byte (lsb) as the second argument, so `txt_pitchbend(int chan, int lsb, int msb)` receives them correctly named. The bug was purely in the `printf`: labels read `lsb= msb=` but arguments were passed `(msb, lsb)`, so each value showed under the wrong label.

The fix corrects the mismatch and, while there, presents the bytes **most-significant first** (`msb=%d lsb=%d`), since the 14-bit bend value is `msb*128 + lsb`, which reads more naturally for a human.

This is a **display-only** change in the text dump — MIDI generation is unaffected.

### Before / after
```
- Time=241  Pitchbend, chan=1 lsb=48 msb=0     (mislabeled)
+ Time=241  Pitchbend, chan=1 msb=48 lsb=0     (correct, msb-first)
```

## Tests

The golden suite pipes `abc2midi` output through `mftext`, so six golden references (daramud, demo_11, detune, detune_2, temperament, temperament_2) had baked in the old mislabeled lines. They've been regenerated; the diff touches **only** `Pitchbend` lines (0 other changes). All 34 golden tests pass.

Closes #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)